### PR TITLE
Add codecov to CI #18

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -58,6 +58,12 @@ jobs:
       - name: Run unit tests
         run: pytest -c test/pytest.ini test/unit/ --cov
 
+      - name: Upload coverage reports to Codecov
+        if: success()
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   e2e-tests:
     needs: [unit-tests]
     name: End-to-End Tests


### PR DESCRIPTION
## Description

Adds codecov to the CI.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #18 
