### PR TITLE
Add get endpoint for image metadata

### DIFF
--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -57,7 +57,7 @@ class ImageRepo:
             return ImageOut(**image)
         return None
 
-    def list(self, session: ClientSession = None) -> list[ImageOut]:
+    def list(self, entity_id: Optional[str], primary: Optional[bool], session: ClientSession = None) -> list[ImageOut]:
         """
         Retrieve Images from a MongoDB database.
 
@@ -65,5 +65,18 @@ class ImageRepo:
         :return: List of Images or an empty list if no Images are retrieved
         """
 
-        images = self._images_collection.find(session=session)
+        query = {}
+        if entity_id is not None:
+            query["entity_id":entity_id]
+        if primary is not None:
+            query["primary":primary]
+
+        message = "Retrieving all images from the database"
+        if not query:
+            logger.info(message)
+        else:
+            logger.info("%s matching the provided filter(s)", message)
+            logger.debug("Provided filter(s): %s", query)
+
+        images = self._images_collection.find(query, session=session)
         return [ImageOut(**image) for image in images]

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -67,9 +67,9 @@ class ImageRepo:
 
         query = {}
         if entity_id is not None:
-            query["entity_id":entity_id]
+            query["entity_id"] = CustomObjectId(entity_id)
         if primary is not None:
-            query["primary":primary]
+            query["primary"] = primary
 
         message = "Retrieving all images from the database"
         if not query:

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -56,3 +56,14 @@ class ImageRepo:
         if image:
             return ImageOut(**image)
         return None
+
+    def list(self, session: ClientSession = None) -> list[ImageOut]:
+        """
+        Retrieve Images from a MongoDB database.
+
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: List of Images or an empty list if no Images are retrieved
+        """
+
+        images = self._images_collection.find(session=session)
+        return [ImageOut(**image) for image in images]

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -68,7 +68,7 @@ class ImageRepo:
         """
 
         query = {}
-        if entity_id:
+        if entity_id is not None:
             query["entity_id"] = CustomObjectId(entity_id)
         if primary is not None:
             query["primary"] = primary

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -59,14 +59,16 @@ class ImageRepo:
 
     def list(self, entity_id: Optional[str], primary: Optional[bool], session: ClientSession = None) -> list[ImageOut]:
         """
-        Retrieve Images from a MongoDB database.
+        Retrieve images from a MongoDB database.
 
         :param session: PyMongo ClientSession to use for database operations.
-        :return: List of Images or an empty list if no Images are retrieved
+        :param entity_id: The ID of the entity to filter images by.
+        :param primary: The primary value to filter images by.
+        :return: List of images or an empty list if no images are retrieved.
         """
 
         query = {}
-        if entity_id is not None:
+        if entity_id:
             query["entity_id"] = CustomObjectId(entity_id)
         if primary is not None:
             query["primary"] = primary

--- a/object_storage_api/routers/image.py
+++ b/object_storage_api/routers/image.py
@@ -61,10 +61,9 @@ def get_images(
     # pylint: disable=missing-function-docstring
     logger.info("Getting images")
 
-    if entity_id:
+    if entity_id is not None:
         logger.debug("Entity ID filter: '%s'", entity_id)
-
-    if primary:
+    if primary is not None:
         logger.debug("Primary filter: '%s'", primary)
 
     return image_service.list(entity_id, primary)

--- a/object_storage_api/routers/image.py
+++ b/object_storage_api/routers/image.py
@@ -49,11 +49,25 @@ def create_image(
     return image_service.create(image_metadata, upload_file)
 
 
-@router.get(path="", summary="retrieve a list of images", status_code=status.HTTP_200_OK)
+@router.get(
+    path="",
+    summary="retrieve a list of images",
+    response_description="a list of images",
+    status_code=status.HTTP_200_OK,
+)
 def get_image_list(
     image_service: ImageServiceDep,
     entity_id: Annotated[str | None, Query()] = None,
     primary: Annotated[bool | None, Query()] = None,
 ) -> list[ImageSchema]:
-    images = image_service.list()
-    return (ImageSchema(**image) for image in images)
+    # pylint: disable=missing-function-docstring
+    logger.info("Getting images")
+
+    if entity_id:
+        logger.debug("Entity ID filter: '%s'", entity_id)
+
+    if primary:
+        logger.debug("Primary filter: '%s'", primary)
+    images = image_service.list(entity_id, primary)
+
+    return (ImageSchema(**image.model_dump()) for image in images)

--- a/object_storage_api/routers/image.py
+++ b/object_storage_api/routers/image.py
@@ -6,8 +6,9 @@ service.
 import logging
 from typing import Annotated, Optional
 
-from fastapi import APIRouter, Depends, File, Form, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
 
+from object_storage_api.models.image import ImageOut
 from object_storage_api.schemas.image import ImagePostMetadataSchema, ImageSchema
 from object_storage_api.services.image import ImageService
 
@@ -46,3 +47,13 @@ def create_image(
     logger.debug("Image upload file: %s", upload_file)
 
     return image_service.create(image_metadata, upload_file)
+
+
+@router.get(path="", summary="retrieve a list of images", status_code=status.HTTP_200_OK)
+def get_image_list(
+    image_service: ImageServiceDep,
+    entity_id: Annotated[str | None, Query()] = None,
+    primary: Annotated[bool | None, Query()] = None,
+) -> list[ImageSchema]:
+    images = image_service.list()
+    return (ImageSchema(**image) for image in images)

--- a/object_storage_api/routers/image.py
+++ b/object_storage_api/routers/image.py
@@ -8,7 +8,6 @@ from typing import Annotated, Optional
 
 from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
 
-from object_storage_api.models.image import ImageOut
 from object_storage_api.schemas.image import ImagePostMetadataSchema, ImageSchema
 from object_storage_api.services.image import ImageService
 

--- a/object_storage_api/routers/image.py
+++ b/object_storage_api/routers/image.py
@@ -50,14 +50,13 @@ def create_image(
 
 @router.get(
     path="",
-    summary="retrieve a list of images",
-    response_description="a list of images",
-    status_code=status.HTTP_200_OK,
+    summary="Get images",
+    response_description="List of images",
 )
-def get_image_list(
+def get_images(
     image_service: ImageServiceDep,
-    entity_id: Annotated[str | None, Query()] = None,
-    primary: Annotated[bool | None, Query()] = None,
+    entity_id: Annotated[Optional[str], Query(description="Filter images by entity ID")] = None,
+    primary: Annotated[Optional[bool], Query(description="Filter images by primary")] = None,
 ) -> list[ImageSchema]:
     # pylint: disable=missing-function-docstring
     logger.info("Getting images")
@@ -67,6 +66,5 @@ def get_image_list(
 
     if primary:
         logger.debug("Primary filter: '%s'", primary)
-    images = image_service.list(entity_id, primary)
 
-    return (ImageSchema(**image.model_dump()) for image in images)
+    return image_service.list(entity_id, primary)

--- a/object_storage_api/services/image.py
+++ b/object_storage_api/services/image.py
@@ -11,7 +11,7 @@ from fastapi import Depends, UploadFile
 
 from object_storage_api.core.exceptions import InvalidObjectIdError
 from object_storage_api.core.image import generate_thumbnail_base64_str
-from object_storage_api.models.image import ImageIn
+from object_storage_api.models.image import ImageIn, ImageOut
 from object_storage_api.repositories.image import ImageRepo
 from object_storage_api.schemas.image import ImagePostMetadataSchema, ImageSchema
 from object_storage_api.stores.image import ImageStore
@@ -74,3 +74,12 @@ class ImageService:
         image_out = self._image_repository.create(image_in)
 
         return ImageSchema(**image_out.model_dump())
+
+    def list(self) -> list[ImageOut]:
+        """
+        Retrieve a list of all Images
+
+        :return: List of Images or an empty list if no Images are retrieved
+        """
+
+        return self._image_repository.list()

--- a/object_storage_api/services/image.py
+++ b/object_storage_api/services/image.py
@@ -75,11 +75,13 @@ class ImageService:
 
         return ImageSchema(**image_out.model_dump())
 
-    def list(self, entity_id: Optional[str], primary: Optional[bool]) -> list[ImageOut]:
+    def list(self, entity_id: Optional[str] = None, primary: Optional[bool] = None) -> list[ImageSchema]:
         """
-        Retrieve a list of all Images
+        Retrieve a list of all images.
 
-        :return: List of Images or an empty list if no Images are retrieved
+        :param entity_id: The ID of the entity to filter images by.
+        :param primary: The primary value to filter images by.
+        :return: List of images or an empty list if no images are retrieved.
         """
-
-        return self._image_repository.list(entity_id, primary)
+        images = self._image_repository.list(entity_id, primary)
+        return [ImageSchema(**image.model_dump()) for image in images]

--- a/object_storage_api/services/image.py
+++ b/object_storage_api/services/image.py
@@ -4,7 +4,7 @@ store.
 """
 
 import logging
-from typing import Annotated
+from typing import Annotated, Optional
 
 from bson import ObjectId
 from fastapi import Depends, UploadFile
@@ -75,11 +75,11 @@ class ImageService:
 
         return ImageSchema(**image_out.model_dump())
 
-    def list(self) -> list[ImageOut]:
+    def list(self, entity_id: Optional[str], primary: Optional[bool]) -> list[ImageOut]:
         """
         Retrieve a list of all Images
 
         :return: List of Images or an empty list if no Images are retrieved
         """
 
-        return self._image_repository.list()
+        return self._image_repository.list(entity_id, primary)

--- a/object_storage_api/services/image.py
+++ b/object_storage_api/services/image.py
@@ -11,7 +11,7 @@ from fastapi import Depends, UploadFile
 
 from object_storage_api.core.exceptions import InvalidObjectIdError
 from object_storage_api.core.image import generate_thumbnail_base64_str
-from object_storage_api.models.image import ImageIn, ImageOut
+from object_storage_api.models.image import ImageIn
 from object_storage_api.repositories.image import ImageRepo
 from object_storage_api.schemas.image import ImagePostMetadataSchema, ImageSchema
 from object_storage_api.stores.image import ImageStore
@@ -77,7 +77,7 @@ class ImageService:
 
     def list(self, entity_id: Optional[str] = None, primary: Optional[bool] = None) -> list[ImageSchema]:
         """
-        Retrieve a list of all images.
+        Retrieve a list of images based on the provided filters.
 
         :param entity_id: The ID of the entity to filter images by.
         :param primary: The primary value to filter images by.

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -28,6 +28,7 @@ def fixture_cleanup_database_collections():
     database = get_database()
     yield
     database.attachments.delete_many({})
+    database.images.delete_many({})
 
 
 @pytest.fixture(name="cleanup_object_storage_bucket", autouse=True)

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -3,7 +3,7 @@ Module for providing common test configuration, test fixtures, and helper functi
 """
 
 from sqlite3 import Cursor
-from typing import List, Optional
+from typing import List
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -72,7 +72,6 @@ class RepositoryTestHelpers:
 
         :param collection_mock: Mocked MongoDB database collection instance.
         :param documents: The list of documents to be returned by the `find` method.
-
         """
 
         cursor_mock = MagicMock(Cursor)

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -66,7 +66,7 @@ class RepositoryTestHelpers:
             collection_mock.find_one.side_effect = documents
 
     @staticmethod
-    def mock_find(collection_mock: Mock, documents: List[dict], query: Optional[dict] = None) -> None:
+    def mock_find(collection_mock: Mock, documents: List[dict]) -> None:
         """
         Mocks the `find` method of the MongoDB database collection mock to return a specific list of documents.
 
@@ -74,13 +74,7 @@ class RepositoryTestHelpers:
         :param documents: The list of documents to be returned by the `find` method.
 
         """
-        if query is None:
-            filtered_documents = documents
-        else:
-            filtered_documents = [
-                doc for doc in documents if all(query_param in doc.items() for query_param in query.items())
-            ]
 
         cursor_mock = MagicMock(Cursor)
-        cursor_mock.__iter__.return_value = iter(filtered_documents)
+        cursor_mock.__iter__.return_value = iter(documents)
         collection_mock.find.return_value = cursor_mock

--- a/test/unit/repositories/test_image.py
+++ b/test/unit/repositories/test_image.py
@@ -4,10 +4,13 @@ Unit tests for the `ImageRepo` repository.
 
 from test.mock_data import IMAGE_IN_DATA_ALL_VALUES
 from test.unit.repositories.conftest import RepositoryTestHelpers
+from typing import Optional
 from unittest.mock import MagicMock, Mock
 
 import pytest
+from bson import ObjectId
 
+from object_storage_api.core.custom_object_id import CustomObjectId
 from object_storage_api.models.image import ImageIn, ImageOut
 from object_storage_api.repositories.image import ImageRepo
 
@@ -84,3 +87,73 @@ class TestCreate(CreateDSL):
         self.mock_create(IMAGE_IN_DATA_ALL_VALUES)
         self.call_create()
         self.check_create_success()
+
+
+class ListDSL(ImageRepoDSL):
+    """Base class for `list` tests."""
+
+    _expected_image_out: list[ImageOut]
+    _obtained_image_out: list[ImageOut]
+
+    def mock_list(self, image_in_data: list[dict], query: dict = None) -> None:
+        """
+        Mocks database methods appropriately to test the `list` repo method.
+
+        :param image_in_data: List of dictionaries containing the image data as would be required for an
+            `ImageIn` database model (i.e. no ID or created and modified times required).
+        """
+        self._expected_image_out = [
+            ImageOut(**ImageIn(**image_in_data).model_dump()) for image_in_data in image_in_data
+        ]
+
+        RepositoryTestHelpers.mock_find(
+            self.images_collection, [image_out.model_dump() for image_out in self._expected_image_out], query=query
+        )
+
+    def call_list(self, entity_id: Optional[str], primary: Optional[bool]) -> None:
+        """Calls the `ImageRepo` `list method` method."""
+        self._obtained_image_out = self.image_repository.list(
+            session=self.mock_session, entity_id=entity_id, primary=primary
+        )
+
+    def check_list_success(self, query: Optional[dict] = None) -> None:
+        """Checks that a prior call to `call_list` worked as expected."""
+        self.images_collection.find.assert_called_once_with(session=self.mock_session, query=query)
+        assert self._obtained_image_out == self._expected_image_out
+
+
+class TestList(ListDSL):
+    """Tests for listing images"""
+
+    def test_list(self):
+        """Test listing all images."""
+        self.mock_list([IMAGE_IN_DATA_ALL_VALUES])
+        self.call_list()
+        self.check_list_success()
+
+    def test_list_with_no_results(self):
+        """Test listing all images returning no results."""
+        self.mock_list([])
+        self.call_list()
+        self.check_list_success()
+
+    def test_list(self):
+        """Test listing all images with an entity_id argument."""
+        query = {"entity_id": IMAGE_IN_DATA_ALL_VALUES["entity_id"]}
+        self.mock_list([IMAGE_IN_DATA_ALL_VALUES], query=query)
+        self.call_list(entity_id=query["entity_id"])
+        self.check_list_success(query)
+
+    def test_list(self):
+        """Test listing all images with a primary argument."""
+        query = {"primary": False}
+        self.mock_list([IMAGE_IN_DATA_ALL_VALUES], query=query)
+        self.call_list(primary=query["primary"])
+        self.check_list_success(query)
+
+    def test_list(self):
+        """Test listing all images with an entity_id and primary argument."""
+        query = {"entity_id": IMAGE_IN_DATA_ALL_VALUES["entity_id"], "primary": False}
+        self.mock_list([IMAGE_IN_DATA_ALL_VALUES], query=query)
+        self.call_list(primary=query["primary"], entity_id=query["entity_id"])
+        self.check_list_success(query)

--- a/test/unit/repositories/test_image.py
+++ b/test/unit/repositories/test_image.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock, Mock
 import pytest
 from bson import ObjectId
 
-from object_storage_api.core.custom_object_id import CustomObjectId
 from object_storage_api.models.image import ImageIn, ImageOut
 from object_storage_api.repositories.image import ImageRepo
 
@@ -116,10 +115,12 @@ class ListDSL(ImageRepoDSL):
             session=self.mock_session, entity_id=entity_id, primary=primary
         )
 
-    def check_list_success(self, query: Optional[dict] = {}) -> None:
+    def check_list_success(self, query: Optional[dict] = None) -> None:
         """Checks that a prior call to `call_list` worked as expected."""
 
-        if query:
+        if query is None:
+            query = {}
+        elif "entity_id" in query:
             query["entity_id"] = ObjectId(query["entity_id"])
 
         self.images_collection.find.assert_called_once_with(query, session=self.mock_session)
@@ -141,21 +142,21 @@ class TestList(ListDSL):
         self.call_list()
         self.check_list_success()
 
-    def test_list(self):
+    def test_list_with_entity_id(self):
         """Test listing all images with an entity_id argument."""
         query = {"entity_id": IMAGE_IN_DATA_ALL_VALUES["entity_id"]}
         self.mock_list([IMAGE_IN_DATA_ALL_VALUES], query=query)
         self.call_list(entity_id=query["entity_id"])
         self.check_list_success(query)
 
-    def test_list(self):
+    def test_list_with_primary(self):
         """Test listing all images with a primary argument."""
         query = {"primary": False}
         self.mock_list([IMAGE_IN_DATA_ALL_VALUES], query=query)
         self.call_list(primary=query["primary"])
         self.check_list_success(query)
 
-    def test_list(self):
+    def test_list_with_primary_and_entity_id(self):
         """Test listing all images with an entity_id and primary argument."""
         query = {"entity_id": IMAGE_IN_DATA_ALL_VALUES["entity_id"], "primary": False}
         self.mock_list([IMAGE_IN_DATA_ALL_VALUES], query=query)

--- a/test/unit/repositories/test_image.py
+++ b/test/unit/repositories/test_image.py
@@ -110,15 +110,19 @@ class ListDSL(ImageRepoDSL):
             self.images_collection, [image_out.model_dump() for image_out in self._expected_image_out], query=query
         )
 
-    def call_list(self, entity_id: Optional[str], primary: Optional[bool]) -> None:
+    def call_list(self, entity_id: Optional[str] = None, primary: Optional[bool] = None) -> None:
         """Calls the `ImageRepo` `list method` method."""
         self._obtained_image_out = self.image_repository.list(
             session=self.mock_session, entity_id=entity_id, primary=primary
         )
 
-    def check_list_success(self, query: Optional[dict] = None) -> None:
+    def check_list_success(self, query: Optional[dict] = {}) -> None:
         """Checks that a prior call to `call_list` worked as expected."""
-        self.images_collection.find.assert_called_once_with(session=self.mock_session, query=query)
+
+        if query:
+            query["entity_id"] = ObjectId(query["entity_id"])
+
+        self.images_collection.find.assert_called_once_with(query, session=self.mock_session)
         assert self._obtained_image_out == self._expected_image_out
 
 

--- a/test/unit/repositories/test_image.py
+++ b/test/unit/repositories/test_image.py
@@ -126,9 +126,9 @@ class ListDSL(ImageRepoDSL):
     def check_list_success(self) -> None:
         """Checks that a prior call to `call_list` worked as expected."""
         expected_query = {}
-        if self._entity_id_filter:
+        if self._entity_id_filter is not None:
             expected_query["entity_id"] = ObjectId(self._entity_id_filter)
-        if self._primary_filter != None:
+        if self._primary_filter is not None:
             expected_query["primary"] = self._primary_filter
 
         self.images_collection.find.assert_called_once_with(expected_query, session=self.mock_session)
@@ -151,19 +151,19 @@ class TestList(ListDSL):
         self.check_list_success()
 
     def test_list_with_entity_id(self):
-        """Test listing all images with an entity_id argument."""
+        """Test listing all images with an `entity_id` argument."""
         self.mock_list([IMAGE_IN_DATA_ALL_VALUES])
         self.call_list(entity_id=IMAGE_IN_DATA_ALL_VALUES["entity_id"])
         self.check_list_success()
 
     def test_list_with_primary(self):
-        """Test listing all images with a primary argument."""
+        """Test listing all images with a `primary` argument."""
         self.mock_list([IMAGE_IN_DATA_ALL_VALUES])
         self.call_list(primary=False)
         self.check_list_success()
 
     def test_list_with_primary_and_entity_id(self):
-        """Test listing all images with an entity_id and primary argument."""
+        """Test listing all images with an `entity_id` and `primary` argument."""
         self.mock_list([IMAGE_IN_DATA_ALL_VALUES])
-        self.call_list(primary=False, entity_id=IMAGE_IN_DATA_ALL_VALUES["entity_id"])
+        self.call_list(primary=True, entity_id=IMAGE_IN_DATA_ALL_VALUES["entity_id"])
         self.check_list_success()

--- a/test/unit/services/test_image.py
+++ b/test/unit/services/test_image.py
@@ -166,6 +166,8 @@ class TestCreate(CreateDSL):
 class ListDSL(ImageServiceDSL):
     """Base class for `list` tests."""
 
+    _entity_id_filter: Optional[str]
+    _primary_filter: Optional[str]
     _expected_images: MagicMock
     _obtained_images: MagicMock
 
@@ -173,16 +175,18 @@ class ListDSL(ImageServiceDSL):
         """Mocks repo methods appropriately to test the `list` service method."""
 
         self._expected_images = MagicMock()
-        self.mock_usage_status_repository.list.return_value = self._expected_images
+        self.mock_image_repository.list.return_value = self._expected_images
 
-    def call_list(self, entity_id: Optional[str], primary: Optional[bool]) -> None:
+    def call_list(self, entity_id: Optional[str] = None, primary: Optional[bool] = None) -> None:
         """Calls the `UsageStatusService` `list` method."""
+        self._entity_id_filter = entity_id
+        self._primary_filter = primary
         self._obtained_images = self.image_service.list(entity_id=entity_id, primary=primary)
 
     def check_list_success(self) -> None:
         """Checks that a prior call to `call_list` worked as expected."""
-        self.mock_image_repository.list.assert_called_once()
-        assert self._obtained_usage_statuses == self._expected_usage_statuses
+        self.mock_image_repository.list.assert_called_once_with(self._entity_id_filter, self._primary_filter)
+        assert self._obtained_images == self._expected_images
 
 
 class TestList(ListDSL):
@@ -190,6 +194,8 @@ class TestList(ListDSL):
 
     def test_list(self):
         """Test listing usage statuses."""
+        entity_id = str(ObjectId())
+        primary = False
         self.mock_list()
-        self.call_list()
+        self.call_list(entity_id, primary)
         self.check_list_success()

--- a/test/unit/services/test_image.py
+++ b/test/unit/services/test_image.py
@@ -2,7 +2,7 @@
 Unit tests for the `ImageService` service.
 """
 
-from test.mock_data import IMAGE_GET_DATA_ALL_VALUES, IMAGE_IN_DATA_ALL_VALUES, IMAGE_POST_METADATA_DATA_ALL_VALUES
+from test.mock_data import IMAGE_IN_DATA_ALL_VALUES, IMAGE_POST_METADATA_DATA_ALL_VALUES
 from typing import List, Optional
 from unittest.mock import MagicMock, Mock, patch
 
@@ -171,16 +171,13 @@ class ListDSL(ImageServiceDSL):
     _expected_images: List[ImageSchema]
     _obtained_images: List[ImageSchema]
 
-    def mock_list(self, image_in_data: list[dict]) -> None:
+    def mock_list(self) -> None:
         """Mocks repo methods appropriately to test the `list` service method."""
 
-        self._expected_images = [
-            ImageSchema(**ImageOut(**ImageIn(**image_in_data).model_dump()).model_dump())
-            for image_in_data in image_in_data
-        ]
-        self.mock_image_repository.list.return_value = [
-            ImageOut(**ImageIn(**image_in_data).model_dump()) for image_in_data in image_in_data
-        ]
+        # Just returns the result after converting it to the schemas currently, so actual value doesn't matter here
+        images_out = [ImageOut(**ImageIn(**IMAGE_IN_DATA_ALL_VALUES).model_dump())]
+        self.mock_image_repository.list.return_value = images_out
+        self._expected_images = [ImageSchema(**image_out.model_dump()) for image_out in images_out]
 
     def call_list(self, entity_id: Optional[str] = None, primary: Optional[bool] = None) -> None:
         """Calls the `ImageService` `list` method.
@@ -203,6 +200,6 @@ class TestList(ListDSL):
 
     def test_list(self):
         """Test listing images."""
-        self.mock_list([IMAGE_IN_DATA_ALL_VALUES])
+        self.mock_list()
         self.call_list(entity_id=str(ObjectId()), primary=False)
         self.check_list_success()

--- a/test/unit/services/test_image.py
+++ b/test/unit/services/test_image.py
@@ -178,7 +178,7 @@ class ListDSL(ImageServiceDSL):
         self.mock_image_repository.list.return_value = self._expected_images
 
     def call_list(self, entity_id: Optional[str] = None, primary: Optional[bool] = None) -> None:
-        """Calls the `UsageStatusService` `list` method."""
+        """Calls the `ImageService` `list` method."""
         self._entity_id_filter = entity_id
         self._primary_filter = primary
         self._obtained_images = self.image_service.list(entity_id=entity_id, primary=primary)
@@ -190,10 +190,10 @@ class ListDSL(ImageServiceDSL):
 
 
 class TestList(ListDSL):
-    """Tests for listing usage statuses."""
+    """Tests for listing images."""
 
     def test_list(self):
-        """Test listing usage statuses."""
+        """Test listing images."""
         entity_id = str(ObjectId())
         primary = False
         self.mock_list()

--- a/test/unit/services/test_image.py
+++ b/test/unit/services/test_image.py
@@ -3,6 +3,7 @@ Unit tests for the `ImageService` service.
 """
 
 from test.mock_data import IMAGE_POST_METADATA_DATA_ALL_VALUES
+from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -160,3 +161,35 @@ class TestCreate(CreateDSL):
         self.mock_create({**IMAGE_POST_METADATA_DATA_ALL_VALUES, "entity_id": "invalid-id"})
         self.call_create_expecting_error(InvalidObjectIdError)
         self.check_create_failed_with_exception("Invalid ObjectId value 'invalid-id'")
+
+
+class ListDSL(ImageServiceDSL):
+    """Base class for `list` tests."""
+
+    _expected_images: MagicMock
+    _obtained_images: MagicMock
+
+    def mock_list(self) -> None:
+        """Mocks repo methods appropriately to test the `list` service method."""
+
+        self._expected_images = MagicMock()
+        self.mock_usage_status_repository.list.return_value = self._expected_images
+
+    def call_list(self, entity_id: Optional[str], primary: Optional[bool]) -> None:
+        """Calls the `UsageStatusService` `list` method."""
+        self._obtained_images = self.image_service.list(entity_id=entity_id, primary=primary)
+
+    def check_list_success(self) -> None:
+        """Checks that a prior call to `call_list` worked as expected."""
+        self.mock_image_repository.list.assert_called_once()
+        assert self._obtained_usage_statuses == self._expected_usage_statuses
+
+
+class TestList(ListDSL):
+    """Tests for listing usage statuses."""
+
+    def test_list(self):
+        """Test listing usage statuses."""
+        self.mock_list()
+        self.call_list()
+        self.check_list_success()


### PR DESCRIPTION
## Description
Implements a `GET` `/images` that:
- [x] Returns a list of images
- [x] Accepts an optional query parameter `entity_id` that filters results by the `entity_id` via the database
- [x] Accepts an optional query parameter `primary` that filters results by the `primary` value via the database

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #36