### PR TITLE
Revert "Add download url to endpoint for getting a single image #93"

### DIFF
--- a/object_storage_api/schemas/image.py
+++ b/object_storage_api/schemas/image.py
@@ -38,5 +38,4 @@ class ImageMetadataSchema(CreatedModifiedSchemaMixin, ImagePostMetadataSchema):
 class ImageSchema(ImageMetadataSchema):
     """Schema model for an image get request response."""
 
-    view_url: HttpUrl = Field(description="Presigned get URL to view the image file")
-    download_url: HttpUrl = Field(description="Presigned get URL to download the image file")
+    url: HttpUrl = Field(description="Presigned get URL to get the image file")

--- a/object_storage_api/services/image.py
+++ b/object_storage_api/services/image.py
@@ -90,14 +90,14 @@ class ImageService:
 
     def get(self, image_id: str) -> ImageSchema:
         """
-        Retrieve an image's metadata with its presigned get download and view urls by its ID.
+        Retrieve an image's metadata with its presigned get url by its ID.
 
         :param image_id: ID of the image to retrieve.
-        :return: An image's metadata with its presigned get urls.
+        :return: An image's metadata with a presigned get url.
         """
         image = self._image_repository.get(image_id=image_id)
-        view_url, download_url = self._image_store.create_presigned_get(image)
-        return ImageSchema(**image.model_dump(), view_url=view_url, download_url=download_url)
+        presigned_url = self._image_store.create_presigned_get(image)
+        return ImageSchema(**image.model_dump(), url=presigned_url)
 
     def list(self, entity_id: Optional[str] = None, primary: Optional[bool] = None) -> list[ImageMetadataSchema]:
         """

--- a/object_storage_api/stores/image.py
+++ b/object_storage_api/stores/image.py
@@ -39,38 +39,25 @@ class ImageStore:
 
         return object_key
 
-    def create_presigned_get(self, image: ImageOut) -> tuple[str, str]:
+    def create_presigned_get(self, image: ImageOut) -> str:
         """
         Generate a presigned URL to share an S3 object.
 
         :param image: `ImageOut` model of the image.
-        :return: Presigned urls to view and download the image.
+        :return: Presigned url to get the image.
         """
         logger.info("Generating presigned url to get image with object key: %s from the object store", image.object_key)
-
-        parameters = {
-            "ClientMethod": "get_object",
-            "Params": {
+        response = s3_client.generate_presigned_url(
+            "get_object",
+            Params={
                 "Bucket": object_storage_config.bucket_name.get_secret_value(),
                 "Key": image.object_key,
                 "ResponseContentDisposition": f'inline; filename="{image.file_name}"',
             },
-            "ExpiresIn": object_storage_config.presigned_url_expiry_seconds,
-        }
-
-        view_url = s3_client.generate_presigned_url(**parameters)
-
-        download_url = s3_client.generate_presigned_url(
-            **{
-                **parameters,
-                "Params": {
-                    **parameters["Params"],
-                    "ResponseContentDisposition": f'attachment; filename="{image.file_name}"',
-                },
-            }
+            ExpiresIn=object_storage_config.presigned_url_expiry_seconds,
         )
 
-        return view_url, download_url
+        return response
 
     def delete(self, object_key: str) -> None:
         """

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -185,6 +185,5 @@ IMAGE_GET_METADATA_DATA_ALL_VALUES_AFTER_PATCH = {
 
 IMAGE_GET_DATA_ALL_VALUES = {
     **IMAGE_GET_METADATA_DATA_ALL_VALUES,
-    "view_url": ANY,
-    "download_url": ANY,
+    "url": ANY,
 }

--- a/test/unit/repositories/test_image.py
+++ b/test/unit/repositories/test_image.py
@@ -299,7 +299,10 @@ class UpdateDSL(ImageRepoDSL):
         """
         self._image_in = ImageIn(**new_image_in_data)
 
-    def mock_update(self, new_image_in_data: dict) -> None:
+    def mock_update(
+        self,
+        new_image_in_data: dict,
+    ) -> None:
         """
         Mocks database methods appropriately to test the `update` repo method.
 

--- a/test/unit/services/test_image.py
+++ b/test/unit/services/test_image.py
@@ -198,14 +198,9 @@ class GetDSL(ImageServiceDSL):
 
         self._expected_image_out = ImageOut(**ImageIn(**IMAGE_IN_DATA_ALL_VALUES).model_dump())
         self.mock_image_repository.get.return_value = self._expected_image_out
-        self.mock_image_store.create_presigned_get.return_value = (
-            "https://fakepresignedurl.co.uk/inline",
-            "https://fakepresignedurl.co.uk/attachment",
-        )
+        self.mock_image_store.create_presigned_get.return_value = "https://fakepresignedurl.co.uk"
         self._expected_image = ImageSchema(
-            **self._expected_image_out.model_dump(),
-            view_url="https://fakepresignedurl.co.uk/inline",
-            download_url="https://fakepresignedurl.co.uk/attachment",
+            **self._expected_image_out.model_dump(), url="https://fakepresignedurl.co.uk"
         )
 
     def call_get(self, image_id: str) -> None:


### PR DESCRIPTION
Reverts ral-facilities/object-storage-api#94

I mistakenly merged the Backend PR that changes url to download_url and view_url. The corresponding front end PR is not ready yet, meaning there is currently a mismatch between the url attribute names.

The PR needs to be reverted until the front end is ready