### PR TITLE
Move invalid entity id error handling to repository layer for attachments and images #79

### DIFF
--- a/object_storage_api/repositories/attachment.py
+++ b/object_storage_api/repositories/attachment.py
@@ -87,9 +87,9 @@ class AttachmentRepo:
             try:
                 query["entity_id"] = CustomObjectId(entity_id)
             except InvalidObjectIdError as exc:
-                exc.status_code = 422
-                exc.response_detail = "Attachment not found"
-                raise exc
+                # As this endpoint filters, and to hide the database behaviour, we treat any invalid id
+                # the same as a valid one that doesn't exist i.e. return an empty list
+                return []
 
         message = "Retrieving all attachments from the database"
         if not query:

--- a/object_storage_api/repositories/attachment.py
+++ b/object_storage_api/repositories/attachment.py
@@ -75,7 +75,6 @@ class AttachmentRepo:
         :param session: PyMongo ClientSession to use for database operations.
         :param entity_id: The ID of the entity to filter attachments by.
         :return: List of attachments or an empty list if no attachments are retrieved.
-        :raises InvalidObjectIdError: If the supplied `entity_id` is invalid.
         """
 
         # There is some duplicate code here, due to the attachments and images methods being very similar
@@ -87,7 +86,7 @@ class AttachmentRepo:
             try:
                 query["entity_id"] = CustomObjectId(entity_id)
             except InvalidObjectIdError:
-                # As this endpoint filters, and to hide the database behaviour, we treat any invalid id
+                # As this method filters, and to hide the database behaviour, we treat any invalid id
                 # the same as a valid one that doesn't exist i.e. return an empty list
                 return []
 

--- a/object_storage_api/repositories/attachment.py
+++ b/object_storage_api/repositories/attachment.py
@@ -75,14 +75,21 @@ class AttachmentRepo:
         :param session: PyMongo ClientSession to use for database operations.
         :param entity_id: The ID of the entity to filter attachments by.
         :return: List of attachments or an empty list if no attachments are retrieved.
+        :raises InvalidObjectIdError: If the supplied `entity_id` is invalid.
         """
 
         # There is some duplicate code here, due to the attachments and images methods being very similar
         # pylint: disable=duplicate-code
 
         query = {}
+
         if entity_id is not None:
-            query["entity_id"] = CustomObjectId(entity_id)
+            try:
+                query["entity_id"] = CustomObjectId(entity_id)
+            except InvalidObjectIdError as exc:
+                exc.status_code = 422
+                exc.response_detail = "Attachment not found"
+                raise exc
 
         message = "Retrieving all attachments from the database"
         if not query:

--- a/object_storage_api/repositories/attachment.py
+++ b/object_storage_api/repositories/attachment.py
@@ -86,7 +86,7 @@ class AttachmentRepo:
         if entity_id is not None:
             try:
                 query["entity_id"] = CustomObjectId(entity_id)
-            except InvalidObjectIdError as exc:
+            except InvalidObjectIdError:
                 # As this endpoint filters, and to hide the database behaviour, we treat any invalid id
                 # the same as a valid one that doesn't exist i.e. return an empty list
                 return []

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -76,7 +76,6 @@ class ImageRepo:
         :param entity_id: The ID of the entity to filter images by.
         :param primary: The primary value to filter images by.
         :return: List of images or an empty list if no images are retrieved.
-        :raises InvalidObjectIdError: If the supplied `image_id` is invalid.
         """
 
         # There is some duplicate code here, due to the attachments and images methods being very similar
@@ -88,7 +87,7 @@ class ImageRepo:
             try:
                 query["entity_id"] = CustomObjectId(entity_id)
             except InvalidObjectIdError:
-                # As this endpoint filters, and to hide the database behaviour, we treat any invalid id
+                # As this method filters, and to hide the database behaviour, we treat any invalid id
                 # the same as a valid one that doesn't exist i.e. return an empty list
                 return []
 

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -87,7 +87,7 @@ class ImageRepo:
         if entity_id is not None:
             try:
                 query["entity_id"] = CustomObjectId(entity_id)
-            except InvalidObjectIdError as exc:
+            except InvalidObjectIdError:
                 # As this endpoint filters, and to hide the database behaviour, we treat any invalid id
                 # the same as a valid one that doesn't exist i.e. return an empty list
                 return []

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -88,9 +88,9 @@ class ImageRepo:
             try:
                 query["entity_id"] = CustomObjectId(entity_id)
             except InvalidObjectIdError as exc:
-                exc.status_code = 422
-                exc.response_detail = "Image not found"
-                raise exc
+                # As this endpoint filters, and to hide the database behaviour, we treat any invalid id
+                # the same as a valid one that doesn't exist i.e. return an empty list
+                return []
 
         if primary is not None:
             query["primary"] = primary

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -76,14 +76,22 @@ class ImageRepo:
         :param entity_id: The ID of the entity to filter images by.
         :param primary: The primary value to filter images by.
         :return: List of images or an empty list if no images are retrieved.
+        :raises InvalidObjectIdError: If the supplied `image_id` is invalid.
         """
 
         # There is some duplicate code here, due to the attachments and images methods being very similar
         # pylint: disable=duplicate-code
 
         query = {}
+
         if entity_id is not None:
-            query["entity_id"] = CustomObjectId(entity_id)
+            try:
+                query["entity_id"] = CustomObjectId(entity_id)
+            except InvalidObjectIdError as exc:
+                exc.status_code = 422
+                exc.response_detail = "Image not found"
+                raise exc
+
         if primary is not None:
             query["primary"] = primary
 

--- a/test/e2e/test_attachment.py
+++ b/test/e2e/test_attachment.py
@@ -253,12 +253,6 @@ class ListDSL(GetDSL):
         assert self._get_response_attachment.status_code == 200
         assert self._get_response_attachment.json() == expected_attachments_get_data
 
-    def check_get_attachments_failed_with_message(self, status_code, expected_detail, obtained_detail):
-        """Checks the response of listing attachments failed with the expected message."""
-
-        assert self._get_response_attachment.status_code == status_code
-        assert obtained_detail == expected_detail
-
 
 class TestList(ListDSL):
     """Tests for getting a list of attachments."""
@@ -300,14 +294,12 @@ class TestList(ListDSL):
         """
         Test getting a list of all attachments with an invalid `entity_id` filter provided.
 
-        Posts three attachments and expects a 422 status code.
+        Posts three attachments and expects no results.
         """
 
         self.post_test_attachments()
         self.get_attachments(filters={"entity_id": False})
-        self.check_get_attachments_failed_with_message(
-            422, "Attachment not found", self._get_response_attachment.json()["detail"]
-        )
+        self.check_get_attachments_success([])
 
 
 class DeleteDSL(ListDSL):

--- a/test/e2e/test_attachment.py
+++ b/test/e2e/test_attachment.py
@@ -306,7 +306,7 @@ class TestList(ListDSL):
         self.post_test_attachments()
         self.get_attachments(filters={"entity_id": False})
         self.check_get_attachments_failed_with_message(
-            422, "Invalid ID given", self._get_response_attachment.json()["detail"]
+            422, "Attachment not found", self._get_response_attachment.json()["detail"]
         )
 
 

--- a/test/e2e/test_image.py
+++ b/test/e2e/test_image.py
@@ -302,7 +302,7 @@ class TestList(ListDSL):
         """
         self.post_test_images()
         self.get_images(filters={"entity_id": False})
-        self.check_get_images_failed_with_message(422, "Invalid ID given", self._get_response_image.json()["detail"])
+        self.check_get_images_failed_with_message(422, "Image not found", self._get_response_image.json()["detail"])
 
     def test_list_with_primary_filter(self):
         """

--- a/test/e2e/test_image.py
+++ b/test/e2e/test_image.py
@@ -298,11 +298,11 @@ class TestList(ListDSL):
         """
         Test getting a list of all images with an invalid `entity_id` filter provided.
 
-        Posts 3 images and expects a 422 status code.
+        Posts 3 images and expects no results.
         """
         self.post_test_images()
         self.get_images(filters={"entity_id": False})
-        self.check_get_images_failed_with_message(422, "Image not found", self._get_response_image.json()["detail"])
+        self.check_get_images_success([])
 
     def test_list_with_primary_filter(self):
         """

--- a/test/unit/repositories/test_attachment.py
+++ b/test/unit/repositories/test_attachment.py
@@ -155,7 +155,7 @@ class GetDSL(AttachmentRepoDSL):
         Checks that a prior call to `call_get_expecting_error` worked as expected, raising an exception
         with the correct message.
 
-        :param attachment_id: ID of the expected attachment to appear in the exception detail.
+        :param message: Expected message of the raised exception.
         :param assert_find: If `True` it asserts whether a `find_one` call was made,
             else it asserts that no call was made.
         """
@@ -205,6 +205,7 @@ class ListDSL(AttachmentRepoDSL):
     _expected_attachment_out: list[AttachmentOut]
     _entity_id_filter: Optional[str]
     _obtained_attachment_out: list[AttachmentOut]
+    _list_exception: pytest.ExceptionInfo
 
     def mock_list(self, attachment_in_data: list[dict]) -> None:
         """
@@ -225,12 +226,26 @@ class ListDSL(AttachmentRepoDSL):
 
     def call_list(self, entity_id: Optional[str] = None) -> None:
         """
-        Calls the `AttachmentRepo` `list method` method.
+        Calls the `AttachmentRepo` `list` method.
 
         :param entity_id: The ID of the entity to filter attachments by.
         """
         self._entity_id_filter = entity_id
         self._obtained_attachment_out = self.attachment_repository.list(session=self.mock_session, entity_id=entity_id)
+
+    def call_list_expecting_error(self, entity_id: str, error_type: type[BaseException]) -> None:
+        """
+        Calls the `AttachmentRepo` `list` method with the appropriate data from a prior call to `mock_list`
+        while expecting an error to be raised.
+
+        :param entity_id: ID of the entity to filter attachments by.
+        :param error_type: Expected exception to be raised.
+        """
+
+        self._entity_id_filter = entity_id
+        with pytest.raises(error_type) as exc:
+            self.attachment_repository.list(session=self.mock_session, entity_id=entity_id)
+        self._list_exception = exc
 
     def check_list_success(self) -> None:
         """Checks that a prior call to `call_list` worked as expected."""
@@ -240,6 +255,18 @@ class ListDSL(AttachmentRepoDSL):
 
         self.attachments_collection.find.assert_called_once_with(expected_query, session=self.mock_session)
         assert self._obtained_attachment_out == self._expected_attachment_out
+
+    def check_list_failed_with_exception(self, message: str) -> None:
+        """
+        Checks that a prior call to `call_list_expecting_error` worked as expected, raising an exception
+        with the correct message.
+
+        :param message: Expected message of the raised exception.
+        """
+
+        self.attachments_collection.find.assert_not_called()
+
+        assert str(self._list_exception.value) == message
 
 
 # Expect some duplicate code inside tests as the tests for the different entities can be very similar
@@ -251,21 +278,33 @@ class TestList(ListDSL):
 
     def test_list(self):
         """Test listing all attachments."""
+
         self.mock_list([ATTACHMENT_IN_DATA_ALL_VALUES])
         self.call_list()
         self.check_list_success()
 
     def test_list_with_no_results(self):
         """Test listing all attachments returning no results."""
+
         self.mock_list([])
         self.call_list()
         self.check_list_success()
 
     def test_list_with_entity_id(self):
         """Test listing all attachments with an `entity_id` argument."""
+
         self.mock_list([ATTACHMENT_IN_DATA_ALL_VALUES])
         self.call_list(entity_id=ATTACHMENT_IN_DATA_ALL_VALUES["entity_id"])
         self.check_list_success()
+
+    def test_list_with_invalid_id(self):
+        """Test listing all attachments with an invalid `entity_id` argument."""
+
+        entity_id = "invalid-id"
+
+        self.mock_list([ATTACHMENT_IN_DATA_ALL_VALUES])
+        self.call_list_expecting_error(entity_id, InvalidObjectIdError)
+        self.check_list_failed_with_exception(f"Invalid ObjectId value '{entity_id}'")
 
 
 class DeleteDSL(AttachmentRepoDSL):

--- a/test/unit/repositories/test_image.py
+++ b/test/unit/repositories/test_image.py
@@ -149,7 +149,7 @@ class GetDSL(ImageRepoDSL):
         Checks that a prior call to `call_get_expecting_error` worked as expected, raising an exception
         with the correct message.
 
-        :param image_id: ID of the expected image to appear in the exception detail.
+        :param message: Expected message of the raised exception.
         :param assert_find: If `True` it asserts whether a `find_one` call was made,
             else it asserts that no call was made.
         """
@@ -200,6 +200,7 @@ class ListDSL(ImageRepoDSL):
     _entity_id_filter: Optional[str]
     _primary_filter: Optional[bool]
     _obtained_image_out: list[ImageOut]
+    _list_exception: pytest.ExceptionInfo
 
     def mock_list(self, image_in_data: list[dict]) -> None:
         """
@@ -217,7 +218,7 @@ class ListDSL(ImageRepoDSL):
         )
 
     def call_list(self, entity_id: Optional[str] = None, primary: Optional[bool] = None) -> None:
-        """Calls the `ImageRepo` `list method` method.
+        """Calls the `ImageRepo` `list` method.
 
         :param entity_id: The ID of the entity to filter images by.
         :param primary: The primary value to filter images by.
@@ -227,6 +228,20 @@ class ListDSL(ImageRepoDSL):
         self._obtained_image_out = self.image_repository.list(
             session=self.mock_session, entity_id=entity_id, primary=primary
         )
+
+    def call_list_expecting_error(self, entity_id: str, error_type: type[BaseException]) -> None:
+        """
+        Calls the `ImageRepo` `list` method with the appropriate data from a prior call to `mock_list`
+        while expecting an error to be raised.
+
+        :param entity_id: ID of the entity to filter images by.
+        :param error_type: Expected exception to be raised.
+        """
+
+        self._entity_id_filter = entity_id
+        with pytest.raises(error_type) as exc:
+            self.image_repository.list(session=self.mock_session, entity_id=entity_id, primary=False)
+        self._list_exception = exc
 
     def check_list_success(self) -> None:
         """Checks that a prior call to `call_list` worked as expected."""
@@ -239,6 +254,18 @@ class ListDSL(ImageRepoDSL):
         self.images_collection.find.assert_called_once_with(expected_query, session=self.mock_session)
         assert self._obtained_image_out == self._expected_image_out
 
+    def check_list_failed_with_exception(self, message:str) -> None:
+        """
+        Checks that a prior call to `call_list_expecting_error` worked as expected, raising an exception
+        with the correct message.
+
+        :param message: Expected message of the raised exception.
+        """
+
+        self.images_collection.find.assert_not_called()
+
+        assert str(self._list_exception.value) == message
+
 
 # Expect some duplicate code inside tests as the tests for the different entities can be very similar
 # pylint: disable=duplicate-code
@@ -249,33 +276,47 @@ class TestList(ListDSL):
 
     def test_list(self):
         """Test listing all images."""
+
         self.mock_list([IMAGE_IN_DATA_ALL_VALUES])
         self.call_list()
         self.check_list_success()
 
     def test_list_with_no_results(self):
         """Test listing all images returning no results."""
+
         self.mock_list([])
         self.call_list()
         self.check_list_success()
 
     def test_list_with_entity_id(self):
         """Test listing all images with an `entity_id` argument."""
+
         self.mock_list([IMAGE_IN_DATA_ALL_VALUES])
         self.call_list(entity_id=IMAGE_IN_DATA_ALL_VALUES["entity_id"])
         self.check_list_success()
 
     def test_list_with_primary(self):
         """Test listing all images with a `primary` argument."""
+
         self.mock_list([IMAGE_IN_DATA_ALL_VALUES])
         self.call_list(primary=False)
         self.check_list_success()
 
     def test_list_with_primary_and_entity_id(self):
         """Test listing all images with an `entity_id` and `primary` argument."""
+
         self.mock_list([IMAGE_IN_DATA_ALL_VALUES])
         self.call_list(primary=True, entity_id=IMAGE_IN_DATA_ALL_VALUES["entity_id"])
         self.check_list_success()
+
+    def test_list_with_invalid_id(self):
+        """Test listing all images with an invalid `entity_id` argument."""
+
+        entity_id = "invalid-id"
+
+        self.mock_list([IMAGE_IN_DATA_ALL_VALUES])
+        self.call_list_expecting_error(entity_id, InvalidObjectIdError)
+        self.check_list_failed_with_exception(f"Invalid ObjectId value '{entity_id}'")
 
 
 # pylint: enable=duplicate-code

--- a/test/unit/repositories/test_image.py
+++ b/test/unit/repositories/test_image.py
@@ -254,7 +254,7 @@ class ListDSL(ImageRepoDSL):
         self.images_collection.find.assert_called_once_with(expected_query, session=self.mock_session)
         assert self._obtained_image_out == self._expected_image_out
 
-    def check_list_failed_with_exception(self, message:str) -> None:
+    def check_list_failed_with_exception(self, message: str) -> None:
         """
         Checks that a prior call to `call_list_expecting_error` worked as expected, raising an exception
         with the correct message.


### PR DESCRIPTION
## Description

Moves the invalid entity-id error handling to the repository layer for both attachments and images.
Returns an empty list `[]` instead of error message.
Adds new tests for an invalid entity-id in repository unit tests.
Edits e2e tests as now no error is returned.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking

Resolves #79
