### PR TITLE
Implement endpoint for deleting attachments by entity ID

### DIFF
--- a/object_storage_api/repositories/attachment.py
+++ b/object_storage_api/repositories/attachment.py
@@ -72,8 +72,8 @@ class AttachmentRepo:
         """
         Retrieve attachments from a MongoDB database.
 
-        :param session: PyMongo ClientSession to use for database operations.
         :param entity_id: The ID of the entity to filter attachments by.
+        :param session: PyMongo ClientSession to use for database operations.
         :return: List of attachments or an empty list if no attachments are retrieved.
         """
 
@@ -101,7 +101,7 @@ class AttachmentRepo:
         Delete an attachment by its ID from a MongoDB database.
 
         :param attachment_id: The ID of the attachment to delete.
-        :param session: PyMongo ClientSession to use for database operations
+        :param session: PyMongo ClientSession to use for database operations.
         :raises MissingRecordError: If the supplied `attachment_id` is non-existent.
         :raises InvalidObjectIdError: If the supplied `attachment_id` is invalid.
         """
@@ -114,4 +114,17 @@ class AttachmentRepo:
             raise exc
         response = self._attachments_collection.delete_one(filter={"_id": attachment_id}, session=session)
         if response.deleted_count == 0:
-            raise MissingRecordError(f"No attachment found with ID: {attachment_id}", "attachment")
+            raise MissingRecordError(f"No attachment found with ID: {attachment_id}", entity_name="attachment")
+
+    def delete_by_entity_id(self, entity_id: str, session: Optional[ClientSession] = None) -> None:
+        """
+        Delete attachments by entity ID.
+
+        :param entity_id: The entity ID of the attachments to delete.
+        :param session: PyMongo ClientSession to use for database operations.
+        :return:
+        """
+        logger.info("Deleting attachments with entity ID: %s from the database", entity_id)
+        entity_id = CustomObjectId(entity_id)
+        # Given it is deleting multiple, we are not raising an exception if no attachments were found to be deleted
+        self._attachments_collection.delete_many(filter={"entity_id": entity_id}, session=session)

--- a/object_storage_api/repositories/attachment.py
+++ b/object_storage_api/repositories/attachment.py
@@ -122,9 +122,13 @@ class AttachmentRepo:
 
         :param entity_id: The entity ID of the attachments to delete.
         :param session: PyMongo ClientSession to use for database operations.
-        :return:
         """
         logger.info("Deleting attachments with entity ID: %s from the database", entity_id)
-        entity_id = CustomObjectId(entity_id)
-        # Given it is deleting multiple, we are not raising an exception if no attachments were found to be deleted
-        self._attachments_collection.delete_many(filter={"entity_id": entity_id}, session=session)
+        try:
+            entity_id = CustomObjectId(entity_id)
+            # Given it is deleting multiple, we are not raising an exception if no attachments were found to be deleted
+            self._attachments_collection.delete_many(filter={"entity_id": entity_id}, session=session)
+        except InvalidObjectIdError:
+            # As this method takes in an entity_id to delete multiple attachments, and to hide the database behaviour,
+            # we treat any invalid entity_id the same as a valid one that has no attachments associated to it.
+            pass

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -150,4 +150,4 @@ class ImageRepo:
             raise exc
         response = self._images_collection.delete_one(filter={"_id": image_id}, session=session)
         if response.deleted_count == 0:
-            raise MissingRecordError(f"No image found with ID: {image_id}", "image")
+            raise MissingRecordError(f"No image found with ID: {image_id}", entity_name="image")

--- a/object_storage_api/routers/attachment.py
+++ b/object_storage_api/routers/attachment.py
@@ -8,7 +8,6 @@ from typing import Annotated, Optional
 
 from fastapi import APIRouter, Depends, Path, Query, status
 
-from object_storage_api.core.exceptions import InvalidObjectIdError
 from object_storage_api.schemas.attachment import (
     AttachmentMetadataSchema,
     AttachmentPostResponseSchema,
@@ -97,9 +96,4 @@ def delete_attachments_by_entity_id(
 ) -> None:
     # pylint: disable=missing-function-docstring
     logger.info("Deleting attachments with entity ID: %s", entity_id)
-    try:
-        attachment_service.delete_by_entity_id(entity_id)
-    except InvalidObjectIdError:
-        # As this endpoint takes in a query parameter to delete multiple attachments, and to hide the database
-        # behaviour, we treat any invalid entity_id the same as a valid one that has no attachments associated to it.
-        pass
+    attachment_service.delete_by_entity_id(entity_id)

--- a/object_storage_api/services/attachment.py
+++ b/object_storage_api/services/attachment.py
@@ -101,3 +101,17 @@ class AttachmentService:
         # Deletes attachment from object store first to prevent unreferenced objects in storage
         self._attachment_store.delete(stored_attachment.object_key)
         self._attachment_repository.delete(attachment_id)
+
+    def delete_by_entity_id(self, entity_id: str) -> None:
+        """
+        Delete attachments by entity ID.
+
+        :param entity_id: The entity ID of the attachments to delete.
+        """
+        stored_attachments = self._attachment_repository.list(entity_id)
+        if stored_attachments:
+            # Deletes attachments from object store first to prevent unreferenced objects in storage
+            self._attachment_store.delete_many(
+                [stored_attachment.object_key for stored_attachment in stored_attachments]
+            )
+            self._attachment_repository.delete_by_entity_id(entity_id)

--- a/object_storage_api/stores/attachment.py
+++ b/object_storage_api/stores/attachment.py
@@ -105,5 +105,5 @@ class AttachmentStore:
             batch = object_keys[i : i + batch_size]
             s3_client.delete_objects(
                 Bucket=object_storage_config.bucket_name.get_secret_value(),
-                Delete={"Objects": [{"Key": key for key in batch}]},
+                Delete={"Objects": [{"Key": key} for key in batch]},
             )

--- a/object_storage_api/stores/attachment.py
+++ b/object_storage_api/stores/attachment.py
@@ -88,3 +88,22 @@ class AttachmentStore:
             Bucket=object_storage_config.bucket_name.get_secret_value(),
             Key=object_key,
         )
+
+    def delete_many(self, object_keys: list[str]) -> None:
+        """
+        Deletes given attachments from object storage by object keys.
+
+        It does this in batches due to the `delete_objects` request only allowing a list of up to 1000 keys.
+
+        :param object_keys: Keys of the attachments to delete.
+        """
+        logger.info("Deleting attachment files with object keys: %s from the object store", object_keys)
+
+        batch_size = 1000
+        # Loop through the list of object keys in steps of `batch_size`
+        for i in range(0, len(object_keys), batch_size):
+            batch = object_keys[i : i + batch_size]
+            s3_client.delete_objects(
+                Bucket=object_storage_config.bucket_name.get_secret_value(),
+                Delete={"Objects": [{"Key": key for key in batch}]},
+            )

--- a/test/e2e/test_attachment.py
+++ b/test/e2e/test_attachment.py
@@ -360,3 +360,48 @@ class TestDelete(DeleteDSL):
         """Test deleting an attachment with an invalid ID."""
         self.delete_attachment("invalid_id")
         self.check_delete_attachment_failed_with_detail(404, "Attachment not found")
+
+
+class DeleteByEntityIdDSL(ListDSL):
+    """Base class for delete tests."""
+
+    _delete_response_attachments: Response
+
+    def delete_attachments_by_entity_id(self, entity_id: str) -> None:
+        """
+        Deletes attachments with the given entity ID.
+
+        :param entity_id: Entity ID of the attachments to be deleted.
+        """
+        self._delete_response_attachments = self.test_client.delete("/attachments", params={"entity_id": entity_id})
+
+    def check_delete_attachments_by_entity_id_success(self) -> None:
+        """
+        Checks that a prior call to `delete_attachments_by_entity_id` gave a successful response with the expected code.
+        """
+        assert self._delete_response_attachments.status_code == 204
+
+
+class TestDeleteByEntityId(DeleteByEntityIdDSL):
+    """Tests for deleting attachments by entity ID."""
+
+    def test_delete_attachments_by_entity_id(self):
+        """Test deleting attachments."""
+        attachments = self.post_test_attachments()
+        entity_id = attachments[0]["entity_id"]
+
+        self.delete_attachments_by_entity_id(entity_id)
+        self.check_delete_attachments_by_entity_id_success()
+
+        self.get_attachments(filters={"entity_id": entity_id})
+        self.check_get_attachments_success([])
+
+    def test_delete_attachments_by_entity_id_with_non_existent_id(self):
+        """Test deleting attachments with a non-existent entity ID."""
+        self.delete_attachments_by_entity_id(str(ObjectId()))
+        self.check_delete_attachments_by_entity_id_success()
+
+    def test_delete_attachments_by_entity_id_with_invalid_id(self):
+        """Test deleting attachments with an invalid entity ID."""
+        self.delete_attachments_by_entity_id("invalid_id")
+        self.check_delete_attachments_by_entity_id_success()

--- a/test/e2e/test_attachment.py
+++ b/test/e2e/test_attachment.py
@@ -363,7 +363,7 @@ class TestDelete(DeleteDSL):
 
 
 class DeleteByEntityIdDSL(ListDSL):
-    """Base class for delete tests."""
+    """Base class for delete by entity_id tests."""
 
     _delete_response_attachments: Response
 
@@ -385,7 +385,7 @@ class DeleteByEntityIdDSL(ListDSL):
 class TestDeleteByEntityId(DeleteByEntityIdDSL):
     """Tests for deleting attachments by entity ID."""
 
-    def test_delete_attachments_by_entity_id(self):
+    def test_delete_by_entity_id(self):
         """Test deleting attachments."""
         attachments = self.post_test_attachments()
         entity_id = attachments[0]["entity_id"]
@@ -396,12 +396,12 @@ class TestDeleteByEntityId(DeleteByEntityIdDSL):
         self.get_attachments(filters={"entity_id": entity_id})
         self.check_get_attachments_success([])
 
-    def test_delete_attachments_by_entity_id_with_non_existent_id(self):
+    def test_delete_by_entity_id_with_non_existent_id(self):
         """Test deleting attachments with a non-existent entity ID."""
         self.delete_attachments_by_entity_id(str(ObjectId()))
         self.check_delete_attachments_by_entity_id_success()
 
-    def test_delete_attachments_by_entity_id_with_invalid_id(self):
+    def test_delete_by_entity_id_with_invalid_id(self):
         """Test deleting attachments with an invalid entity ID."""
         self.delete_attachments_by_entity_id("invalid_id")
         self.check_delete_attachments_by_entity_id_success()

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -100,7 +100,7 @@ class RepositoryTestHelpers:
         for the code that relies on the `deleted_count` value to work.
 
         :param collection_mock: Mocked MongoDB database collection instance.
-        :param deleted_count: The value to be assigned to the `deleted_count` attribute of the `DeleteResult` object
+        :param deleted_count: The value to be assigned to the `deleted_count` attribute of the `DeleteResult` object.
         """
         delete_result_mock = Mock(DeleteResult)
         delete_result_mock.deleted_count = deleted_count

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -91,3 +91,17 @@ class RepositoryTestHelpers:
         delete_result_mock = Mock(DeleteResult)
         delete_result_mock.deleted_count = deleted_count
         collection_mock.delete_one.return_value = delete_result_mock
+
+    @staticmethod
+    def mock_delete_many(collection_mock: Mock, deleted_count: int) -> None:
+        """
+        Mock the `delete_many` method of the MongoDB database collection mock to return a `DeleteResult` object. The
+        passed `deleted_count` value is returned as the `deleted_count` attribute of the `DeleteResult` object, enabling
+        for the code that relies on the `deleted_count` value to work.
+
+        :param collection_mock: Mocked MongoDB database collection instance.
+        :param deleted_count: The value to be assigned to the `deleted_count` attribute of the `DeleteResult` object
+        """
+        delete_result_mock = Mock(DeleteResult)
+        delete_result_mock.deleted_count = deleted_count
+        collection_mock.delete_many.return_value = delete_result_mock

--- a/test/unit/repositories/test_attachment.py
+++ b/test/unit/repositories/test_attachment.py
@@ -99,7 +99,7 @@ class GetDSL(AttachmentRepoDSL):
     _obtained_attachment_out: AttachmentOut
     _get_exception: pytest.ExceptionInfo
 
-    def mock_get(self, attachment_id: str, attachment_in_data: Optional[dict] = None) -> None:
+    def mock_get(self, attachment_id: str, attachment_in_data: Optional[dict]) -> None:
         """
         Mocks database methods appropriately to test the `get` repo method.
 
@@ -186,7 +186,7 @@ class TestGet(GetDSL):
 
         attachment_id = str(ObjectId())
 
-        self.mock_get(attachment_id)
+        self.mock_get(attachment_id, None)
         self.call_get_expecting_error(attachment_id, MissingRecordError)
         self.check_get_failed_with_exception(f"No attachment found with ID: {attachment_id}", True)
 
@@ -194,7 +194,7 @@ class TestGet(GetDSL):
         """Test getting an attachment with an invalid attachment ID."""
         attachment_id = "invalid-id"
 
-        self.mock_get(attachment_id)
+        self.mock_get(attachment_id, None)
         self.call_get_expecting_error(attachment_id, InvalidObjectIdError)
         self.check_get_failed_with_exception(f"Invalid ObjectId value '{attachment_id}'")
 

--- a/test/unit/stores/test_attachment.py
+++ b/test/unit/stores/test_attachment.py
@@ -69,6 +69,37 @@ class TestDelete(DeleteDSL):
 # pylint: enable=duplicate-code
 
 
+class DeleteManyDSL(AttachmentStoreDSL):
+    """Base class for `delete_many` tests."""
+
+    _delete_many_object_keys: list[str]
+
+    def call_delete_many(self, object_keys: list[str]) -> None:
+        """
+        Calls the `AttachmentStore` `delete_many` method.
+
+        :param object_keys: Keys of the attachment to delete.
+        """
+        self._delete_many_object_keys = object_keys
+        self.attachment_store.delete_many(object_keys)
+
+    def check_delete_many_success(self) -> None:
+        """Checks that a prior call to `call_delete_many` worked as expected."""
+        self.mock_s3_client.delete_objects.assert_called_once_with(
+            Bucket=object_storage_config.bucket_name.get_secret_value(),
+            Delete={"Objects": [{"Key": key for key in self._delete_many_object_keys}]},
+        )
+
+
+class TestDeleteMany(DeleteManyDSL):
+    """Tests for deleting attachments from object storage by object keys."""
+
+    def test_delete_many(self):
+        """Test deleting attachments from object storage."""
+        self.call_delete_many(["object-key"])
+        self.check_delete_many_success()
+
+
 class CreatePresignedPostDSL(AttachmentStoreDSL):
     """Base class for `create_presigned_post` tests."""
 

--- a/test/unit/stores/test_attachment.py
+++ b/test/unit/stores/test_attachment.py
@@ -87,7 +87,7 @@ class DeleteManyDSL(AttachmentStoreDSL):
         """Checks that a prior call to `call_delete_many` worked as expected."""
         self.mock_s3_client.delete_objects.assert_called_once_with(
             Bucket=object_storage_config.bucket_name.get_secret_value(),
-            Delete={"Objects": [{"Key": key for key in self._delete_many_object_keys}]},
+            Delete={"Objects": [{"Key": key} for key in self._delete_many_object_keys]},
         )
 
 


### PR DESCRIPTION
## Description
This PR implements a `DELETE` endpoint at `/attachments` that accepts an `entity_id` query parameter and deletes all attachments with that `entity_id`.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Successfully deletes all attachments associated with the supplied `entity_id`
- [ ] Returns `204` if `entity_id` is invalid or not associated with any attachments

## Agile board tracking
closes #76 