### PR TITLE
Create a production Docker image

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -1,6 +1,11 @@
 name: CI
 on:
   workflow_dispatch:
+    inputs:
+      push-docker-image-to-harbor:
+        description: 'Push Docker Image to Harbor'
+        type: boolean
+        default: false
   pull_request:
   push:
     branches:
@@ -106,3 +111,37 @@ jobs:
       - name: Output docker logs (minio)
         if: failure()
         run: docker logs object-storage-api-minio-1
+
+  docker:
+    # This job builds the production Docker image and if the workflow is manually triggered 
+    # while the `push-docker-image-to-harbor` input is set to `true`, it pushes it to Harbor.
+    needs: [linting, unit-tests, e2e-tests]
+    name: Docker
+    runs-on: ubuntu-latest
+    env:
+      PUSH_DOCKER_IMAGE_TO_HARBOR: ${{ inputs.push-docker-image-to-harbor != null && inputs.push-docker-image-to-harbor || 'false' }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Login to Harbor
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ secrets.HARBOR_URL }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ secrets.HARBOR_URL }}/object-storage-api
+
+      - name: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: .
+          push: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,26 @@ RUN --mount=type=cache,target=/root/.cache \
 CMD ["fastapi", "dev", "object_storage_api/main.py", "--host", "0.0.0.0", "--port", "8000"]
 
 EXPOSE 8000
+
+
+FROM python:3.12.8-alpine3.20@sha256:0c4f778362f30cc50ff734a3e9e7f3b2ae876d8386f470e0c3ee1ab299cec21b as prod
+
+WORKDIR /app
+
+COPY requirements.txt ./
+COPY object_storage_api/ object_storage_api/
+
+RUN --mount=type=cache,target=/root/.cache \
+    set -eux; \
+    \
+    pip install --no-cache-dir --requirement requirements.txt; \
+    \
+    # Create a non-root user to run as \
+    addgroup -g 500 -S object-storage-api; \
+    adduser -S -D -G object-storage-api -H -u 500 -h /app object-storage-api;
+
+USER object-storage-api
+
+CMD ["fastapi", "run", "object_storage_api/main.py", "--host", "0.0.0.0", "--port", "8000"]
+
+EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM python:3.12.8-alpine3.20@sha256:0c4f778362f30cc50ff734a3e9e7f3b2ae876d8386f470e0c3ee1ab299cec21b
+FROM python:3.12.8-alpine3.20@sha256:0c4f778362f30cc50ff734a3e9e7f3b2ae876d8386f470e0c3ee1ab299cec21b as dev
 
-WORKDIR /object-storage-api-run
+WORKDIR /app
 
-COPY requirements.txt ./
+COPY pyproject.toml requirements.txt ./
 COPY object_storage_api/ object_storage_api/
 
 RUN --mount=type=cache,target=/root/.cache \
     set -eux; \
     \
-    python3 -m pip install -r requirements.txt;
+    pip install --no-cache-dir .[dev]; \
+    # Ensure the pinned versions of the production dependencies and subdependencies are installed \
+    pip install --no-cache-dir --requirement requirements.txt;
+
 
 CMD ["fastapi", "dev", "object_storage_api/main.py", "--host", "0.0.0.0", "--port", "8000"]
+
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 services:
   object-storage-api:
     container_name: object_storage_api_container
-    build: .
+    build:
+      context: .
+      target: dev
     volumes:
       - ./object_storage_api:/object-storage-api-run/object_storage_api
       - ./keys:/object-storage-api-run/keys


### PR DESCRIPTION
## Description
This PR refactors the `Dockerfile` so there is a `dev` stage that can be used to build an image for local development and a `prod` stage that can be used to build an image for production. It also adds a new `docker` job to the GitHub Actions CI file to build the production image and if the workflow is manually triggered while the `push-docker-image-to-harbor` input is set to `true`, to push it to Harbor.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #5 