### PR TITLE
Exclude docs from authentication when `API__ROOT_PATH` is set

### DIFF
--- a/object_storage_api/auth/jwt_middleware.py
+++ b/object_storage_api/auth/jwt_middleware.py
@@ -38,7 +38,8 @@ class JWTMiddleware(BaseHTTPMiddleware):
         :return: The JWT access token if authentication is successful.
         :raises HTTPException: If the supplied JWT access token is invalid or has expired.
         """
-        if request.url.path not in [f"{config.api.root_path}/docs", f"{config.api.root_path}/openapi.json"]:
+        # `config.api.root_path` is not part of `request.url.path` so we are not checking for it
+        if request.url.path not in ["/docs", "/openapi.json"]:
             try:
                 credentials: HTTPAuthorizationCredentials = await security(request)
             except HTTPException as exc:


### PR DESCRIPTION
## Description
Makes the necessary changes to exclude the docs (`/docs` and `/openapi.json`) from authentication when `API__ROOT_PATH` is set.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Docs should be exclude from authentication

## Agile board tracking
closes #114 