### PR TITLE
Implement endpoint for deleting attachments by entity ID

### DIFF
--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -158,3 +158,20 @@ class ImageRepo:
         response = self._images_collection.delete_one(filter={"_id": image_id}, session=session)
         if response.deleted_count == 0:
             raise MissingRecordError(f"No image found with ID: {image_id}", entity_name="image")
+
+    def delete_by_entity_id(self, entity_id: str, session: Optional[ClientSession] = None) -> None:
+        """
+        Delete images by entity ID.
+
+        :param entity_id: The entity ID of the images to delete.
+        :param session: PyMongo ClientSession to use for database operations.
+        """
+        logger.info("Deleting images with entity ID: %s from the database", entity_id)
+        try:
+            entity_id = CustomObjectId(entity_id)
+            # Given it is deleting multiple, we are not raising an exception if no images were found to be deleted
+            self._images_collection.delete_many(filter={"entity_id": entity_id}, session=session)
+        except InvalidObjectIdError:
+            # As this method takes in an entity_id to delete multiple attachments, and to hide the database behaviour,
+            # we treat any invalid entity_id the same as a valid one that has no images associated to it.
+            pass

--- a/object_storage_api/routers/image.py
+++ b/object_storage_api/routers/image.py
@@ -115,3 +115,18 @@ def delete_image(
     # pylint: disable=missing-function-docstring
     logger.info("Deleting image with ID: %s", image_id)
     image_service.delete(image_id)
+
+
+@router.delete(
+    path="",
+    summary="Delete images by entity ID",
+    response_description="Images deleted successfully",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_images_by_entity_id(
+    entity_id: Annotated[str, Query(description="The entity ID of the images to delete")],
+    image_service: ImageServiceDep,
+) -> None:
+    # pylint: disable=missing-function-docstring
+    logger.info("Deleting images with entity ID: %s", entity_id)
+    image_service.delete_by_entity_id(entity_id)

--- a/object_storage_api/services/image.py
+++ b/object_storage_api/services/image.py
@@ -149,3 +149,15 @@ class ImageService:
         # Deletes image from object store first to prevent unreferenced objects in storage
         self._image_store.delete(stored_image.object_key)
         self._image_repository.delete(image_id)
+
+    def delete_by_entity_id(self, entity_id: str) -> None:
+        """
+        Delete images by entity ID.
+
+        :param entity_id: The entity ID of the images to delete.
+        """
+        stored_images = self._image_repository.list(entity_id, None)
+        if stored_images:
+            # Deletes images from object store first to prevent unreferenced objects in storage
+            self._image_store.delete_many([stored_image.object_key for stored_image in stored_images])
+            self._image_repository.delete_by_entity_id(entity_id)

--- a/object_storage_api/stores/attachment.py
+++ b/object_storage_api/stores/attachment.py
@@ -99,6 +99,9 @@ class AttachmentStore:
         """
         logger.info("Deleting attachment files with object keys: %s from the object store", object_keys)
 
+        # There is some duplicate code here, due to the attachments and images methods being very similar
+        # pylint: disable=duplicate-code
+
         batch_size = 1000
         # Loop through the list of object keys in steps of `batch_size`
         for i in range(0, len(object_keys), batch_size):
@@ -107,3 +110,5 @@ class AttachmentStore:
                 Bucket=object_storage_config.bucket_name.get_secret_value(),
                 Delete={"Objects": [{"Key": key} for key in batch]},
             )
+
+        # pylint: enable=duplicate-code

--- a/test/e2e/test_attachment.py
+++ b/test/e2e/test_attachment.py
@@ -428,13 +428,13 @@ class TestDelete(DeleteDSL):
 
 
 class DeleteByEntityIdDSL(ListDSL):
-    """Base class for delete by entity_id tests."""
+    """Base class for delete by `entity_id` tests."""
 
     _delete_response_attachments: Response
 
     def delete_attachments_by_entity_id(self, entity_id: str) -> None:
         """
-        Deletes attachments with the given entity ID.
+        Deletes attachments with the given `entity_id`.
 
         :param entity_id: Entity ID of the attachments to be deleted.
         """
@@ -448,7 +448,7 @@ class DeleteByEntityIdDSL(ListDSL):
 
 
 class TestDeleteByEntityId(DeleteByEntityIdDSL):
-    """Tests for deleting attachments by entity ID."""
+    """Tests for deleting attachments by `entity_id`."""
 
     def test_delete_by_entity_id(self):
         """Test deleting attachments."""
@@ -462,11 +462,11 @@ class TestDeleteByEntityId(DeleteByEntityIdDSL):
         self.check_get_attachments_success([])
 
     def test_delete_by_entity_id_with_non_existent_id(self):
-        """Test deleting attachments with a non-existent entity ID."""
+        """Test deleting attachments with a non-existent `entity_id`."""
         self.delete_attachments_by_entity_id(str(ObjectId()))
         self.check_delete_attachments_by_entity_id_success()
 
     def test_delete_by_entity_id_with_invalid_id(self):
-        """Test deleting attachments with an invalid entity ID."""
+        """Test deleting attachments with an invalid `entity_id`."""
         self.delete_attachments_by_entity_id("invalid_id")
         self.check_delete_attachments_by_entity_id_success()

--- a/test/unit/repositories/test_attachment.py
+++ b/test/unit/repositories/test_attachment.py
@@ -377,9 +377,6 @@ class TestDelete(DeleteDSL):
         self.check_delete_failed_with_exception(f"Invalid ObjectId value '{attachment_id}'")
 
 
-# pylint: enable=duplicate-code
-
-
 class DeleteByEntityIdDSL(AttachmentRepoDSL):
     """Base class for `delete_by_entity_id` tests."""
 
@@ -418,7 +415,7 @@ class DeleteByEntityIdDSL(AttachmentRepoDSL):
 
 
 class TestDeleteByEntityId(DeleteByEntityIdDSL):
-    """Tests for deleting attachments by entity ID."""
+    """Tests for deleting attachments by `entity_id`."""
 
     def test_delete_by_entity_id(self):
         """Test deleting attachments."""
@@ -427,11 +424,14 @@ class TestDeleteByEntityId(DeleteByEntityIdDSL):
         self.check_delete_by_entity_id_success()
 
     def test_delete_by_entity_id_invalid_id(self):
-        """Test deleting attachments with an invalid entity ID."""
+        """Test deleting attachments with an invalid `entity_id`."""
         entity_id = "invalid-id"
 
         self.call_delete_by_entity_id(entity_id)
         self.check_delete_by_entity_id_success(False)
+
+
+# pylint: enable=duplicate-code
 
 
 class UpdateDSL(AttachmentRepoDSL):

--- a/test/unit/repositories/test_image.py
+++ b/test/unit/repositories/test_image.py
@@ -98,7 +98,7 @@ class GetDSL(ImageRepoDSL):
     _obtained_image_out: ImageOut
     _get_exception: pytest.ExceptionInfo
 
-    def mock_get(self, image_id: str, image_in_data: dict) -> None:
+    def mock_get(self, image_id: str, image_in_data: Optional[dict] = None) -> None:
         """
         Mocks database methods appropriately to test the `get` repo method.
 
@@ -180,7 +180,7 @@ class TestGet(GetDSL):
 
         image_id = str(ObjectId())
 
-        self.mock_get(image_id, None)
+        self.mock_get(image_id)
         self.call_get_expecting_error(image_id, MissingRecordError)
         self.check_get_failed_with_exception(f"No image found with ID: {image_id}", True)
 
@@ -188,7 +188,7 @@ class TestGet(GetDSL):
         """Test getting an image with an invalid image ID."""
         image_id = "invalid-id"
 
-        self.mock_get(image_id, None)
+        self.mock_get(image_id)
         self.call_get_expecting_error(image_id, InvalidObjectIdError)
         self.check_get_failed_with_exception(f"Invalid ObjectId value '{image_id}'")
 
@@ -299,7 +299,7 @@ class TestList(ListDSL):
         self.check_list_success()
 
     def test_list_with_invalid_id_returns_empty_list(self):
-        """Test listing all attachments with an invalid `entity_id` argument returns an empty list."""
+        """Test listing all images with an invalid `entity_id` argument returns an empty list."""
 
         entity_id = "invalid-id"
 
@@ -533,6 +533,60 @@ class TestDelete(DeleteDSL):
 
         self.call_delete_expecting_error(image_id, InvalidObjectIdError)
         self.check_delete_failed_with_exception(f"Invalid ObjectId value '{image_id}'")
+
+
+class DeleteByEntityIdDSL(ImageRepoDSL):
+    """Base class for `delete_by_entity_id` tests."""
+
+    _delete_entity_id: str
+    _delete_by_entity_id_exception: pytest.ExceptionInfo
+
+    def mock_delete_by_entity_id(self, deleted_count: int) -> None:
+        """
+        Mocks database methods appropriately to test the `delete_by_entity_id` repo method.
+
+        :param deleted_count: Number of documents deleted successfully.
+        """
+        RepositoryTestHelpers.mock_delete_many(self.images_collection, deleted_count)
+
+    def call_delete_by_entity_id(self, entity_id: str) -> None:
+        """
+        Calls the `ImageRepo` `delete_by_entity_id` method.
+
+        :param entity_id: The entity ID of the images to be deleted.
+        """
+        self._delete_entity_id = entity_id
+        self.image_repository.delete_by_entity_id(entity_id, session=self.mock_session)
+
+    def check_delete_by_entity_id_success(self, assert_delete: bool = True) -> None:
+        """
+        Checks that a prior call to `call_delete_by_entity_id` worked as expected.
+
+        :param assert_delete: Whether the `delete_many` method is expected to be called or not.
+        """
+        if assert_delete:
+            self.images_collection.delete_many.assert_called_once_with(
+                filter={"entity_id": ObjectId(self._delete_entity_id)}, session=self.mock_session
+            )
+        else:
+            self.images_collection.delete_many.assert_not_called()
+
+
+class TestDeleteByEntityId(DeleteByEntityIdDSL):
+    """Tests for deleting images by `entity_id`."""
+
+    def test_delete_by_entity_id(self):
+        """Test deleting images."""
+        self.mock_delete_by_entity_id(3)
+        self.call_delete_by_entity_id(str(ObjectId()))
+        self.check_delete_by_entity_id_success()
+
+    def test_delete_by_entity_id_invalid_id(self):
+        """Test deleting images with an invalid `entity_id`."""
+        entity_id = "invalid-id"
+
+        self.call_delete_by_entity_id(entity_id)
+        self.check_delete_by_entity_id_success(False)
 
 
 # pylint: enable=duplicate-code

--- a/test/unit/services/test_attachment.py
+++ b/test/unit/services/test_attachment.py
@@ -465,8 +465,12 @@ class DeleteByEntityIdDSL(AttachmentServiceDSL):
             self.mock_attachment_repository.delete_by_entity_id.assert_not_called()
 
 
+# Expect some duplicate code inside tests as the tests for the different entities can be very similar
+# pylint: disable=duplicate-code
+
+
 class TestDeleteByEntityId(DeleteByEntityIdDSL):
-    """Tests for deleting attachments by entity ID."""
+    """Tests for deleting attachments by `entity_id`."""
 
     def test_delete_by_entity_id(self):
         """Test deleting attachments."""
@@ -475,7 +479,10 @@ class TestDeleteByEntityId(DeleteByEntityIdDSL):
         self.check_delete_by_entity_id_success()
 
     def test_delete_by_entity_id_non_existent_id(self):
-        """Test deleting attachments with a non-existent entity ID."""
+        """Test deleting attachments with a non-existent `entity_id`."""
         self.mock_delete_by_entity_id([])
         self.call_delete_by_entity_id()
         self.check_delete_by_entity_id_success(False)
+
+
+# pylint: enable=duplicate-code

--- a/test/unit/stores/test_attachment.py
+++ b/test/unit/stores/test_attachment.py
@@ -66,9 +66,6 @@ class TestDelete(DeleteDSL):
         self.check_delete_success()
 
 
-# pylint: enable=duplicate-code
-
-
 class DeleteManyDSL(AttachmentStoreDSL):
     """Base class for `delete_many` tests."""
 
@@ -78,7 +75,7 @@ class DeleteManyDSL(AttachmentStoreDSL):
         """
         Calls the `AttachmentStore` `delete_many` method.
 
-        :param object_keys: Keys of the attachment to delete.
+        :param object_keys: Keys of the attachments to delete.
         """
         self._delete_many_object_keys = object_keys
         self.attachment_store.delete_many(object_keys)
@@ -98,6 +95,9 @@ class TestDeleteMany(DeleteManyDSL):
         """Test deleting attachments from object storage."""
         self.call_delete_many(["object-key"])
         self.check_delete_many_success()
+
+
+# pylint: enable=duplicate-code
 
 
 class CreatePresignedPostDSL(AttachmentStoreDSL):

--- a/test/unit/stores/test_image.py
+++ b/test/unit/stores/test_image.py
@@ -118,6 +118,40 @@ class TestDelete(DeleteDSL):
         self.check_delete_success()
 
 
+class DeleteManyDSL(ImageStoreDSL):
+    """Base class for `delete_many` tests."""
+
+    _delete_many_object_keys: list[str]
+
+    def call_delete_many(self, object_keys: list[str]) -> None:
+        """
+        Calls the `ImageStore` `delete_many` method.
+
+        :param object_keys: Keys of the images to delete.
+        """
+        self._delete_many_object_keys = object_keys
+        self.image_store.delete_many(object_keys)
+
+    def check_delete_many_success(self) -> None:
+        """Checks that a prior call to `call_delete_many` worked as expected."""
+        self.mock_s3_client.delete_objects.assert_called_once_with(
+            Bucket=object_storage_config.bucket_name.get_secret_value(),
+            Delete={"Objects": [{"Key": key} for key in self._delete_many_object_keys]},
+        )
+
+
+class TestDeleteMany(DeleteManyDSL):
+    """Tests for deleting images from object storage by object keys."""
+
+    def test_delete_many(self):
+        """Test deleting images from object storage."""
+        self.call_delete_many(["object-key"])
+        self.check_delete_many_success()
+
+
+# pylint: enable=duplicate-code
+
+
 class CreatePresignedURLDSL(ImageStoreDSL):
     """Base class for `create` tests."""
 


### PR DESCRIPTION
## Description
This PR implements a `DELETE` endpoint at `/images` that accepts an `entity_id` query parameter and deletes all images with that `entity_id`.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Successfully deletes all images associated with the supplied `entity_id`
- [ ] Returns `204` if `entity_id` is invalid or not associated with any images

## Agile board tracking
closes #104 