### PR TITLE
Get Docker CI job to pass in Dependabot PRs

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -118,13 +118,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         with:
-          images: ${{ secrets.HARBOR_URL }}/object-storage-api
+          images: ${{ vars.HARBOR_URL }}/object-storage-api
 
       - name: Login to Harbor
         if: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          registry: ${{ secrets.HARBOR_URL }}
+          registry: ${{ vars.HARBOR_URL }}
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
 


### PR DESCRIPTION
## Description
Makes the necessary changes to get the Docker CI job to pass in Dependabot PRs.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build