### PR TITLE
Upgrade boto3 and minio #143

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: example
 
   minio:
-    image: minio/minio:RELEASE.2024-09-13T20-26-02Z
+    image: minio/minio:RELEASE.2025-04-08T15-41-24Z
     container_name: object-storage-minio
     command: minio server /data
     volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.7.0
 anyio==4.9.0
-boto3==1.35.99
-botocore==1.35.99
+boto3==1.37.38
+botocore==1.37.38
 certifi==2025.1.31
 cffi==1.17.1
 click==8.1.8
@@ -37,7 +37,7 @@ python-multipart==0.0.20
 PyYAML==6.0.2
 rich==14.0.0
 rich-toolkit==0.14.1
-s3transfer==0.10.4
+s3transfer==0.11.5
 shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1
@@ -46,7 +46,7 @@ typer==0.15.2
 typing_extensions==4.13.2
 ujson==5.10.0
 urllib3==2.4.0
-uvicorn==0.34.1
+uvicorn==0.34.2
 uvloop==0.21.0
 watchfiles==1.0.5
 websockets==15.0.1


### PR DESCRIPTION
## Description

See #143. This updates boto3 to the latest version (at the time of writing) and also updates minio to fix the e2e tests that failed in the dependabot PRs. I also tested the new package version against echo to ensure it still functions correctly. docker-ims will need the same minio change in order for delete to work correctly.

Due to it being close to the demo I will not merge this or attempt update the demo VM just in case.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #143
