### PR TITLE
Use MongoDB indexing to prevent duplicate names #151

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,10 @@ services:
   mongo-db:
     image: mongo:7.0-jammy
     container_name: object-storage-api-mongodb
+    entrypoint: mongodb_entrypoint.sh
     volumes:
       - ./mongodb/data:/data/db
+      - ./scripts/mongodb_entrypoint.sh:/usr/local/bin/mongodb_entrypoint.sh:ro
     restart: always
     ports:
       - 27018:27017

--- a/scripts/mongodb_entrypoint.sh
+++ b/scripts/mongodb_entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Execute the standard entrypoint to start mongodb, but add the additional parameters to setup the replica set
+echo "Starting MongoDB through default entrypoint..."
+
+# Avoid unbound variable error as there are no parameters in the initialisation command
+if [ "$#" -eq 0 ]; then
+  set -- mongod
+fi
+
+/usr/local/bin/docker-entrypoint.sh "$@" &
+
+# Wait for MongoDB to be ready to run commands on
+echo "Waiting for MongoDB to be ready..."
+until mongosh --username "$MONGO_INITDB_ROOT_USERNAME" --password "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase=admin --eval "db.adminCommand('ping')" > /dev/null 2>&1; do
+  sleep 1
+done
+
+# Initialise indexes if not already setup
+for database_name in object-storage test-object-storage; do
+  if ! mongosh "$database_name" --username "$MONGO_INITDB_ROOT_USERNAME" --password "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase=admin --quiet --eval "db.attachments.getIndexes().forEach(i => print(i.name))" | grep -q '^attachments_code_index$'; then
+    echo "Initialising code index for attachments and images ($database_name)..."
+    mongosh "$database_name" --username "$MONGO_INITDB_ROOT_USERNAME" --password "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase=admin \
+      --eval 'db.attachments.createIndex({ "code": 1 }, { name: "attachments_code_index", unique: true })' \
+      --eval 'db.images.createIndex({ "code": 1 }, { name: "images_code_index", unique: true })'
+  fi
+done
+
+wait


### PR DESCRIPTION
## Description

See #152. Ensures we shouldn't have race conditions due to concurrency which would otherwise allow some images/attachments with duplicate names from getting added to the database. This should not require any specific changes to your local instance, calling `docker compose up` should be sufficient to get the index to be setup.

Will require similar changes for docker-ims to handle the entrypoint script.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Ensure you cannot create images/attachments with duplicate file names (either though creating or editing)

## Agile board tracking

Closes #151
