### PR TITLE
Add release action #134

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,43 @@
+name: Release Build
+on:
+  push:
+    tags: "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    # This job builds the Docker image and if successful, it pushes it to Harbor.
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Login to Harbor
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ vars.HARBOR_URL }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ vars.HARBOR_URL }}/object-storage-api
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=false
+
+      - name: Build and push Docker image to Harbor
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: prod


### PR DESCRIPTION
## Description

Adds a release action (compare with the ims-api one found at https://github.com/ral-facilities/inventory-management-system-api/blob/develop/.github/workflows/release-build.yml). There isn't really any way to test this, other than trying it when we go to use it and fixing it then if necessary, so just need to check the contents look correct here. The only differences are the upload url and the fact it uses a target as its a multistage Dockerfile instead of a separate Dockerfile.prod.

I have also added a wiki page like ims-api pointing to the release instructions https://github.com/ral-facilities/object-storage-api/wiki/Release-Process.


## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code

## Agile board tracking

Closes #134
