### PR TITLE
Revert boto3 upgrade to ensure works with echo #143

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: example
 
   minio:
-    image: minio/minio:RELEASE.2025-04-08T15-41-24Z
+    image: minio/minio:RELEASE.2024-09-13T20-26-02Z
     container_name: object-storage-minio
     command: minio server /data
     volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.7.0
 anyio==4.9.0
-boto3==1.38.12
-botocore==1.38.12
+boto3==1.35.99
+botocore==1.35.99
 certifi==2025.4.26
 cffi==1.17.1
 click==8.1.8
@@ -37,7 +37,7 @@ python-multipart==0.0.20
 PyYAML==6.0.2
 rich==14.0.0
 rich-toolkit==0.14.5
-s3transfer==0.12.0
+s3transfer==0.10.4
 shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1


### PR DESCRIPTION
## Description

Reverting previous PR in #146 as it didn't work with echo. MinIO is also reverted to ensure it behave similarly to the current Echo ensuring dependabot PRs will still fail if they try and upgrade it for the time being.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build

## Agile board tracking

Links to #143 
