### PR TITLE
Update Dockerfile and configuration for Python 3.13 support

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.10-alpine3.21@sha256:9c51ecce261773a684c8345b2d4673700055c513b4d54bc0719337d3e4ee552e as dev
+FROM python:3.13.0-slim as dev
 
 WORKDIR /app
 
@@ -27,7 +27,7 @@ COPY test/ test/
 CMD ["pytest",  "--config-file", "test/pytest.ini", "-v"]
 
 
-FROM python:3.12.10-alpine3.21@sha256:9c51ecce261773a684c8345b2d4673700055c513b4d54bc0719337d3e4ee552e as prod
+FROM python:3.13.0-slim as prod
 
 WORKDIR /app
 
@@ -40,8 +40,8 @@ RUN --mount=type=cache,target=/root/.cache \
     pip install --no-cache-dir --requirement requirements.txt; \
     \
     # Create a non-root user to run as \
-    addgroup -g 500 -S object-storage-api; \
-    adduser -S -D -G object-storage-api -H -u 500 -h /app object-storage-api;
+    groupadd -g 500 object-storage-api; \
+    useradd -u 500 -g object-storage-api -d /app -M -s /sbin/nologin object-storage-api;
 
 USER object-storage-api
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "object-storage_api"
 description = "Python microservice providing an API for handling attachments and images in an S3 object store."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 version = "0.0.1"
 
 dependencies = [


### PR DESCRIPTION
- Updated base images in Dockerfile from Python 3.12 to 3.13 for both development and production stages.
- Changed user and group creation commands to use `groupadd` and `useradd` for compatibility.
- Updated `requires-python` in pyproject.toml to reflect the new minimum Python version.
- Adjusted CI workflow to set up Python 3.13 instead of 3.12.

## Description

Enter a description of the changes here

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking

connect to #162 
