### PR TITLE
Exclude unnecessary modules from test coverage measurement

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,4 @@ coverage:
 ignore:
   - "test/"
   - "object_storage_api/v1/*" # ignore routers as they are tested in the e2e tests
+  - "object_storage_api/main.py" # ignore main.py as contains router and is tested in the e2e tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,4 @@ coverage:
         target: 75
 ignore:
   - "test/"
+  - "object_storage_api/v1/*" # ignore routers as they are tested in the e2e tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,11 @@ dev = [
     "object-storage-api[scripts]",
 ]
 
+[tool.coverage.run]
+omit = [
+    # Exclude routers from coverage measurement as they are tested in the e2e tests
+    "object_storage_api/v1/*"
+]
+
 [tool.setuptools.packages.find]
 include  = ["object_storage_api", "object_storage_api*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ dev = [
 
 [tool.coverage.run]
 omit = [
+    # Exclude test code from coverage measurement
+    "test/*",
     # Exclude routers from coverage measurement as they are tested in the e2e tests
     "object_storage_api/v1/*"
 ]


### PR DESCRIPTION
## Description
Excludes the router modules from the code coverage measurement.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #186 