### PR TITLE
Update dev_cli script to use typer #213

### DIFF
--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -222,6 +222,8 @@ def generate(
     except ImportError:
         exit_with_error("Failed to find generate_mock_data.py")
 
+    console.print("Success! :party_popper:")
+
 
 @app.command()
 def clear(
@@ -233,7 +235,9 @@ def clear(
     yes: YesOption = False,
 ):
     """Clears all data in MongoDB and MinIO."""
+
     clear_existing_data(db_username, db_password, minio_host, minio_username, minio_password, yes)
+    console.print("Success! :party_popper:")
 
 
 def main():

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -60,7 +60,7 @@ def exit_with_error(message: str):
 def run_command(args: list[str], stdin: Optional[TextIOWrapper] = None, stdout: Optional[TextIOWrapper] = None):
     """Runs a command using subprocess."""
 
-    logging.debug("Running command: %s", " ".join(args))
+    console.print(f"[cyan]Running command:[/] [green]{" ".join(args)}[/]")
     # Output using print to ensure order is correct for grouping on github actions (subprocess.run happens before print
     # for some reason)
     with subprocess.Popen(
@@ -68,10 +68,12 @@ def run_command(args: list[str], stdin: Optional[TextIOWrapper] = None, stdout: 
     ) as popen:
         if stdout is None:
             for stdout_line in iter(popen.stdout.readline, ""):
-                print(stdout_line, end="")
+                console.print(stdout_line, end="")
             popen.stdout.close()
         return_code = popen.wait()
-    return return_code
+
+    if return_code != 0:
+        exit_with_error("[red]An error occurred while running the last command![/]")
 
 
 def run_mongodb_command(args: list[str], stdin: Optional[TextIOWrapper] = None, stdout: Optional[TextIOWrapper] = None):

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -1,12 +1,60 @@
 """Module defining a CLI Script for some common development tasks."""
 
-import argparse
+# Expect many arguments as this is a CLI script
+# pylint:disable=too-many-arguments
+# pylint:disable=too-many-positional-arguments
+
 import logging
 import subprocess
-import sys
-from abc import ABC, abstractmethod
 from io import TextIOWrapper
-from typing import Optional
+from typing import Annotated, Optional
+
+import typer
+from rich.console import Console
+
+app = typer.Typer()
+console = Console()
+
+DatabaseUsernameOption = Annotated[
+    str, typer.Option("--db-username", "-dbu", help="Username for MongoDB authentication.", default_factory="root")
+]
+DatabasePasswordOption = Annotated[
+    str,
+    typer.Option("--db-password", "-dbp", help="Password for MongoDB authentication.", default_factory="example"),
+]
+MinIOHostOption = Annotated[
+    str,
+    typer.Option("--minio-host", "-mh", help="Host for MinIO.", default_factory="http://localhost:9000"),
+]
+MinIOUsernameOption = Annotated[
+    str,
+    typer.Option("--minio-username", "-mu", help="Username for MinIO authentication.", default_factory="root"),
+]
+MinIOPasswordOption = Annotated[
+    str,
+    typer.Option(
+        "--minio-password", "-mp", help="Password for MinIO authentication.", default_factory="example_password"
+    ),
+]
+YesOption = Annotated[
+    bool,
+    typer.Option(
+        "--yes",
+        "-y",
+        help="Confirm without any prompts.",
+        # See https://github.com/fastapi/typer/discussions/921 - unfortunately even this doesn't work right now
+        # for setting a default. So have to define manually in each function its used.
+        # default_factory=lambda: False,
+        # show_default="False",
+    ),
+]
+
+
+def exit_with_error(message: str):
+    """Displays an error message in red and then exits."""
+
+    console.print(f"[red bold]{message}[/]")
+    raise typer.Exit(1)
 
 
 def run_command(args: list[str], stdin: Optional[TextIOWrapper] = None, stdout: Optional[TextIOWrapper] = None):
@@ -26,22 +74,6 @@ def run_command(args: list[str], stdin: Optional[TextIOWrapper] = None, stdout: 
     return return_code
 
 
-def start_group(text: str, args: argparse.Namespace):
-    """Print the start of a group for Github CI (to get collapsable sections)."""
-
-    if args.ci:
-        print(f"::group::{text}")
-    else:
-        logging.info(text)
-
-
-def end_group(args: argparse.Namespace):
-    """End of a group for Github CI."""
-
-    if args.ci:
-        print("::endgroup::")
-
-
 def run_mongodb_command(args: list[str], stdin: Optional[TextIOWrapper] = None, stdout: Optional[TextIOWrapper] = None):
     """Runs a command within the mongodb container."""
 
@@ -58,36 +90,20 @@ def run_mongodb_command(args: list[str], stdin: Optional[TextIOWrapper] = None, 
     )
 
 
-def add_mongodb_auth_args(parser: argparse.ArgumentParser):
-    """Adds common arguments for MongoDB authentication."""
-
-    parser.add_argument("-dbu", "--db-username", default="root", help="Username for MongoDB authentication")
-    parser.add_argument("-dbp", "--db-password", default="example", help="Password for MongoDB authentication")
-
-
-def get_mongodb_auth_args(args: argparse.Namespace):
-    """Returns arguments in a list to use the parser arguments defined in `add_mongodb_auth_args` above."""
+def get_mongodb_auth_args(db_username: str, db_password: str):
+    """Returns MongoDB authentication arguments in a list."""
 
     return [
         "--username",
-        args.db_username,
+        db_username,
         "--password",
-        args.db_password,
+        db_password,
         "--authenticationDatabase=admin",
     ]
 
 
-def add_minio_alias_args(parser: argparse.ArgumentParser):
-    """Adds common arguments for a MinIO alias."""
-
-    parser.add_argument("-mu", "--minio-username", default="root", help="Username for MinIO authentication")
-    parser.add_argument("-mp", "--minio-password", default="example_password", help="Password for MinIO authentication")
-    parser.add_argument("-mh", "--minio-host", default="http://localhost:9000", help="Host for MinIO")
-
-
-def set_minio_alias(args: argparse.Namespace):
-    """Sets a MinIO alias named `object_storage` for use before MinIO commands using the parser arguments defined in
-    `add_minio_alias_args` above."""
+def set_minio_alias(minio_host: str, minio_username: str, minio_password: str):
+    """Sets a MinIO alias named `object_storage` for use before MinIO commands."""
 
     run_command(
         [
@@ -99,9 +115,9 @@ def set_minio_alias(args: argparse.Namespace):
             "alias",
             "set",
             "object-storage",
-            args.minio_host,
-            args.minio_username,
-            args.minio_password,
+            minio_host,
+            minio_username,
+            minio_password,
         ],
     )
 
@@ -122,135 +138,105 @@ def run_minio_command(args: list[str], stdin: Optional[TextIOWrapper] = None, st
     )
 
 
-class SubCommand(ABC):
-    """Base class for a sub command."""
+def clear_existing_data(
+    db_username: DatabaseUsernameOption,
+    db_password: DatabasePasswordOption,
+    minio_host: MinIOHostOption,
+    minio_username: MinIOUsernameOption,
+    minio_password: MinIOPasswordOption,
+    yes: YesOption,
+):
+    """Clears any existing data in the database/MinIO. Requires confirmation if yes is false."""
 
-    def __init__(self, help_message: str):
-        self.help_message = help_message
+    # Firstly confirm if ok with deleting
+    if not yes:
+        confirm = typer.confirm("This operation will remove all existing data, are you sure?")
+        if not confirm:
+            raise typer.Abort()
 
-    @abstractmethod
-    def setup(self, parser: argparse.ArgumentParser):
-        """Setup the parser by adding any parameters here."""
+    # Delete the existing data
+    console.print("Deleting database contents...")
+    run_mongodb_command(
+        ["mongosh", "object-storage"]
+        + get_mongodb_auth_args(db_username, db_password)
+        + [
+            "--eval",
+            "db.dropDatabase()",
+        ]
+    )
+    console.print("Deleting MinIO bucket contents...")
 
-    @abstractmethod
-    def run(self, args: argparse.Namespace):
-        """Run the command with the given parameters as added by 'setup'."""
+    # Not ideal that this runs here - would either have to setup once as part of some sort of init (e.g.
+    # could have an init for creating the buckets instead of using the minio/mc image) or would have to
+    # somehow detect if it has already been done. Doesn't seem to be any harm in setting it again here
+    # though.
+    set_minio_alias(minio_host, minio_username, minio_password)
+
+    run_minio_command(["mc", "rm", "--recursive", "--force", "object-storage/object-storage"])
 
 
-class CommandGenerate(SubCommand):
-    """Command to generate new test data for the database and object storage (runs generate_mock_data.py)
-
-    - Deletes all existing data (after confirmation)
-    - Runs generate_mock_data.py
-    """
-
-    def __init__(self):
-        super().__init__(help_message="Generates new test data for the database and dumps it")
-
-    def setup(self, parser: argparse.ArgumentParser):
-        add_mongodb_auth_args(parser)
-        add_minio_alias_args(parser)
-        parser.add_argument(
-            "-c",
+@app.command()
+def generate(
+    db_username: DatabaseUsernameOption,
+    db_password: DatabasePasswordOption,
+    minio_host: MinIOHostOption,
+    minio_username: MinIOUsernameOption,
+    minio_password: MinIOPasswordOption,
+    yes: YesOption = False,
+    clear_existing: Annotated[
+        bool,
+        typer.Option(
             "--clear",
-            action=argparse.BooleanOptionalAction,
-            help="Whether existing data should be cleared before generating new data.",
-        )
-        parser.add_argument(
-            "-e",
-            "--entities",
-            nargs="+",
-            default=None,
-            help="One or more entity IDs to generate attachments and images for.",
-        )
-        parser.add_argument(
-            "-na",
-            "--num-attachments",
-            type=int,
-            default=None,
-            help="Specific number of attachments to generate for each entity.",
-        )
-        parser.add_argument(
-            "-ni",
-            "--num-images",
-            type=int,
-            default=None,
-            help="Specific number of images to generate for each entity.",
-        )
+            "-c",
+            help="Whether existing data should be cleared before generating the new data.",
+        ),
+    ] = False,
+    entities: Annotated[
+        Optional[list[str]],
+        typer.Option("--entity", "-e", help="One or more entity IDs to generate attachments and images for."),
+    ] = None,
+    num_attachments: Annotated[
+        Optional[int],
+        typer.Option("--num-attachments", "-na", help="Specific number of attachments to generate for each entity."),
+    ] = None,
+    num_images: Annotated[
+        Optional[int],
+        typer.Option("--num-images", "-ni", help="Specific number of images to generate for each entity."),
+    ] = None,
+):
+    """Generates new test data for the database and object storage (runs_generate_mock_data.py)."""
 
-    def run(self, args: argparse.Namespace):
-        if args.ci:
-            sys.exit("Cannot use --ci with generate (currently has interactive input)")
+    if clear_existing:
+        clear_existing_data(db_username, db_password, minio_host, minio_username, minio_password, yes)
 
-        if args.clear:
-            # Firstly confirm ok with deleting
-            answer = input("This operation will replace all existing data, are you sure? ")
-            if answer in ("y", "yes"):
-                # Delete the existing data
-                logging.info("Deleting database contents...")
-                run_mongodb_command(
-                    ["mongosh", "object-storage"]
-                    + get_mongodb_auth_args(args)
-                    + [
-                        "--eval",
-                        "db.dropDatabase()",
-                    ]
-                )
-                logging.info("Deleting MinIO bucket contents...")
+    # Generate new data
+    console.print("Generating new mock data...")
+    try:
+        # Import here only because CI wont install necessary packages to import it directly
+        # pylint:disable=import-outside-toplevel
+        from generate_mock_data import generate_mock_data
 
-                # Not ideal that this runs here - would either have to setup once as part of some sort of init (e.g.
-                # could have an init for creating the buckets instead of using the minio/mc image) or would have to
-                # somehow detect if it has already been done. Doesn't seem to be any harm in setting it again here
-                # though.
-                set_minio_alias(args)
-
-                run_minio_command(["mc", "rm", "--recursive", "--force", "object-storage/object-storage"])
-
-        # Generate new data
-        logging.info("Generating new mock data...")
-        try:
-            # Import here only because CI wont install necessary packages to import it directly
-            # pylint:disable=import-outside-toplevel
-            from generate_mock_data import generate_mock_data
-
-            generate_mock_data(
-                entity_ids=args.entities, num_attachments=args.num_attachments, num_images=args.num_images
-            )
-        except ImportError:
-            logging.error("Failed to find generate_mock_data.py")
+        generate_mock_data(entity_ids=entities, num_attachments=num_attachments, num_images=num_images)
+    except ImportError:
+        exit_with_error("Failed to find generate_mock_data.py")
 
 
-# List of subcommands
-commands: dict[str, SubCommand] = {
-    "generate": CommandGenerate(),
-}
+@app.command()
+def clear(
+    db_username: DatabaseUsernameOption,
+    db_password: DatabasePasswordOption,
+    minio_host: MinIOHostOption,
+    minio_username: MinIOUsernameOption,
+    minio_password: MinIOPasswordOption,
+    yes: YesOption = False,
+):
+    """Clears all data in MongoDB and MinIO."""
+    clear_existing_data(db_username, db_password, minio_host, minio_username, minio_password, yes)
 
 
 def main():
-    """Runs CLI commands."""
-
-    parser = argparse.ArgumentParser(prog="ObjectStorage Dev Script", description="Some commands for development")
-    parser.add_argument(
-        "--debug", action="store_true", help="Flag for setting the log level to debug to output more info"
-    )
-    parser.add_argument(
-        "--ci", action="store_true", help="Flag for when running on Github CI (will output groups for collapsing)"
-    )
-
-    subparser = parser.add_subparsers(dest="command")
-
-    for command_name, command in commands.items():
-        command_parser = subparser.add_parser(command_name, help=command.help_message)
-        command.setup(command_parser)
-
-    args = parser.parse_args()
-
-    if args.debug:
-        logging.basicConfig(level=logging.DEBUG)
-    else:
-        logging.basicConfig(level=logging.INFO)
-
-    commands[args.command].run(args)
+    """Entrypoint for the IMS Dev CLI."""
+    app()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Updates the `dev_cli` script to use Typer. The generate command should work as before but now with some more colour and an additional `-y` option. I also add a `clear` command to clear all existing data. (Partially because when there is only one typer ignores the function name and just runs theusing `dev_cli.py` i.e. no generate)

See similar https://github.com/ral-facilities/inventory-management-system-api/pull/608.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #213
