### PR TITLE
Reformat ID mentions in logging and error messages #225

### DIFF
--- a/object_storage_api/repositories/attachment.py
+++ b/object_storage_api/repositories/attachment.py
@@ -61,7 +61,7 @@ class AttachmentRepo:
         :raises InvalidObjectIdError: If the supplied `attachment_id` is invalid.
         """
 
-        logger.info("Retrieving attachment with ID: %s from the database", attachment_id)
+        logger.info("Retrieving attachment with ID '%s' from the database", attachment_id)
 
         try:
             attachment_id = CustomObjectId(attachment_id)
@@ -128,7 +128,7 @@ class AttachmentRepo:
             exc.response_detail = "Attachment not found"
             raise exc
 
-        logger.info("Updating attachment metadata with ID: %s", attachment_id)
+        logger.info("Updating attachment metadata with ID '%s'", attachment_id)
         try:
             self._attachments_collection.update_one(
                 {"_id": attachment_id}, {"$set": attachment.model_dump(by_alias=True)}, session=session
@@ -149,7 +149,7 @@ class AttachmentRepo:
         :raises MissingRecordError: If the supplied `attachment_id` is non-existent.
         :raises InvalidObjectIdError: If the supplied `attachment_id` is invalid.
         """
-        logger.info("Deleting attachment with ID: %s from the database", attachment_id)
+        logger.info("Deleting attachment with ID '%s' from the database", attachment_id)
         try:
             attachment_id = CustomObjectId(attachment_id)
         except InvalidObjectIdError as exc:
@@ -167,7 +167,7 @@ class AttachmentRepo:
         :param entity_id: The entity ID of the attachments to delete.
         :param session: PyMongo ClientSession to use for database operations.
         """
-        logger.info("Deleting attachments with entity ID: %s from the database", entity_id)
+        logger.info("Deleting attachments with entity ID '%s' from the database", entity_id)
         try:
             entity_id = CustomObjectId(entity_id)
             # Given it is deleting multiple, we are not raising an exception if no attachments were found to be deleted
@@ -184,7 +184,7 @@ class AttachmentRepo:
         :param entity_id: The entity ID to use to select which documents to count.
         :param session: PyMongo ClientSession to use for database operations.
         """
-        logger.info("Counting number of attachments with entity ID: %s in the database", str(entity_id))
+        logger.info("Counting number of attachments with entity ID '%s' in the database", str(entity_id))
         return self._attachments_collection.count_documents(
             filter={"entity_id": CustomObjectId(entity_id)}, session=session
         )

--- a/object_storage_api/repositories/attachment.py
+++ b/object_storage_api/repositories/attachment.py
@@ -73,7 +73,7 @@ class AttachmentRepo:
 
         if attachment:
             return AttachmentOut(**attachment)
-        raise MissingRecordError(detail=f"No attachment found with ID: {attachment_id}", entity_type="attachment")
+        raise MissingRecordError(detail=f"No attachment found with ID '{attachment_id}'", entity_type="attachment")
 
     def list(self, entity_id: Optional[str], session: Optional[ClientSession] = None) -> list[AttachmentOut]:
         """
@@ -158,7 +158,7 @@ class AttachmentRepo:
             raise exc
         response = self._attachments_collection.delete_one(filter={"_id": attachment_id}, session=session)
         if response.deleted_count == 0:
-            raise MissingRecordError(f"No attachment found with ID: {attachment_id}", entity_type="attachment")
+            raise MissingRecordError(f"No attachment found with ID '{attachment_id}'", entity_type="attachment")
 
     def delete_by_entity_id(self, entity_id: str, session: Optional[ClientSession] = None) -> None:
         """

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -69,7 +69,7 @@ class ImageRepo:
             raise exc
         if image:
             return ImageOut(**image)
-        raise MissingRecordError(detail=f"No image found with ID: {image_id}", entity_type="image")
+        raise MissingRecordError(detail=f"No image found with ID '{image_id}'", entity_type="image")
 
     def list(
         self, entity_id: Optional[str], primary: Optional[bool], session: Optional[ClientSession] = None
@@ -173,7 +173,7 @@ class ImageRepo:
             raise exc
         response = self._images_collection.delete_one(filter={"_id": image_id}, session=session)
         if response.deleted_count == 0:
-            raise MissingRecordError(f"No image found with ID: {image_id}", entity_type="image")
+            raise MissingRecordError(f"No image found with ID '{image_id}'", entity_type="image")
 
     def delete_by_entity_id(self, entity_id: str, session: Optional[ClientSession] = None) -> None:
         """

--- a/object_storage_api/repositories/image.py
+++ b/object_storage_api/repositories/image.py
@@ -59,7 +59,7 @@ class ImageRepo:
         :raises MissingRecordError: If the supplied `image_id` is non-existent.
         :raises InvalidObjectIdError: If the supplied `image_id` is invalid.
         """
-        logger.info("Retrieving image with ID: %s from the database", image_id)
+        logger.info("Retrieving image with ID '%s' from the database", image_id)
         try:
             image_id = CustomObjectId(image_id)
             image = self._images_collection.find_one({"_id": image_id}, session=session)
@@ -164,7 +164,7 @@ class ImageRepo:
         :raises MissingRecordError: If the supplied `image_id` is non-existent.
         :raises InvalidObjectIdError: If the supplied `image_id` is invalid.
         """
-        logger.info("Deleting image with ID: %s from the database", image_id)
+        logger.info("Deleting image with ID '%s' from the database", image_id)
         try:
             image_id = CustomObjectId(image_id)
         except InvalidObjectIdError as exc:
@@ -182,7 +182,7 @@ class ImageRepo:
         :param entity_id: The entity ID of the images to delete.
         :param session: PyMongo ClientSession to use for database operations.
         """
-        logger.info("Deleting images with entity ID: %s from the database", entity_id)
+        logger.info("Deleting images with entity ID '%s' from the database", entity_id)
         try:
             entity_id = CustomObjectId(entity_id)
             # Given it is deleting multiple, we are not raising an exception if no images were found to be deleted
@@ -199,5 +199,5 @@ class ImageRepo:
         :param entity_id: The entity ID to use to select which documents to count.
         :param session: PyMongo ClientSession to use for database operations.
         """
-        logger.info("Counting number of images with entity ID: %s in the database", entity_id)
+        logger.info("Counting number of images with entity ID '%s' in the database", entity_id)
         return self._images_collection.count_documents(filter={"entity_id": CustomObjectId(entity_id)}, session=session)

--- a/object_storage_api/routers/attachment.py
+++ b/object_storage_api/routers/attachment.py
@@ -65,7 +65,7 @@ def get_attachment(
     attachment_service: AttachmentServiceDep,
 ) -> AttachmentSchema:
     # pylint: disable=missing-function-docstring
-    logger.info("Getting attachment with ID: %s", attachment_id)
+    logger.info("Getting attachment with ID '%s'", attachment_id)
 
     return attachment_service.get(attachment_id)
 
@@ -81,7 +81,7 @@ def partial_update_attachment(
     attachment_service: AttachmentServiceDep,
 ) -> AttachmentMetadataSchema:
     # pylint: disable=missing-function-docstring
-    logger.info("Partially updating attachment with ID: %s", attachment_id)
+    logger.info("Partially updating attachment with ID '%s'", attachment_id)
     logger.debug("Attachment data: %s", attachment)
 
     return attachment_service.update(attachment_id, attachment)
@@ -98,7 +98,7 @@ def delete_attachment(
     attachment_service: AttachmentServiceDep,
 ) -> None:
     # pylint: disable=missing-function-docstring
-    logger.info("Deleting attachment with ID: %s", attachment_id)
+    logger.info("Deleting attachment with ID '%s'", attachment_id)
     attachment_service.delete(attachment_id)
 
 
@@ -113,5 +113,5 @@ def delete_attachments_by_entity_id(
     attachment_service: AttachmentServiceDep,
 ) -> None:
     # pylint: disable=missing-function-docstring
-    logger.info("Deleting attachments with entity ID: %s", entity_id)
+    logger.info("Deleting attachments with entity ID '%s'", entity_id)
     attachment_service.delete_by_entity_id(entity_id)

--- a/object_storage_api/routers/image.py
+++ b/object_storage_api/routers/image.py
@@ -80,7 +80,7 @@ def get_image(
     image_service: ImageServiceDep,
 ) -> ImageSchema:
     # pylint: disable=missing-function-docstring
-    logger.info("Getting image with ID: %s", image_id)
+    logger.info("Getting image with ID '%s'", image_id)
 
     return image_service.get(image_id)
 
@@ -96,7 +96,7 @@ def partial_update_image(
     image_service: ImageServiceDep,
 ) -> ImageMetadataSchema:
     # pylint: disable=missing-function-docstring
-    logger.info("Partially updating image with ID: %s", image_id)
+    logger.info("Partially updating image with ID '%s'", image_id)
     logger.debug("Image data: %s", image)
 
     return image_service.update(image_id, image)
@@ -113,7 +113,7 @@ def delete_image(
     image_service: ImageServiceDep,
 ) -> None:
     # pylint: disable=missing-function-docstring
-    logger.info("Deleting image with ID: %s", image_id)
+    logger.info("Deleting image with ID '%s'", image_id)
     image_service.delete(image_id)
 
 
@@ -128,5 +128,5 @@ def delete_images_by_entity_id(
     image_service: ImageServiceDep,
 ) -> None:
     # pylint: disable=missing-function-docstring
-    logger.info("Deleting images with entity ID: %s", entity_id)
+    logger.info("Deleting images with entity ID '%s'", entity_id)
     image_service.delete_by_entity_id(entity_id)

--- a/test/unit/repositories/test_attachment.py
+++ b/test/unit/repositories/test_attachment.py
@@ -225,7 +225,7 @@ class TestGet(GetDSL):
 
         self.mock_get(attachment_id, None)
         self.call_get_expecting_error(attachment_id, MissingRecordError)
-        self.check_get_failed_with_exception(f"No attachment found with ID: {attachment_id}", True)
+        self.check_get_failed_with_exception(f"No attachment found with ID '{attachment_id}'", True)
 
     def test_get_with_invalid_id(self):
         """Test getting an attachment with an invalid attachment ID."""
@@ -563,7 +563,7 @@ class TestDelete(DeleteDSL):
 
         self.mock_delete(0)
         self.call_delete_expecting_error(attachment_id, MissingRecordError)
-        self.check_delete_failed_with_exception(f"No attachment found with ID: {attachment_id}", assert_delete=True)
+        self.check_delete_failed_with_exception(f"No attachment found with ID '{attachment_id}'", assert_delete=True)
 
     def test_delete_invalid_id(self):
         """Test deleting an attachment with an invalid ID."""

--- a/test/unit/repositories/test_image.py
+++ b/test/unit/repositories/test_image.py
@@ -219,7 +219,7 @@ class TestGet(GetDSL):
 
         self.mock_get(image_id, None)
         self.call_get_expecting_error(image_id, MissingRecordError)
-        self.check_get_failed_with_exception(f"No image found with ID: {image_id}", True)
+        self.check_get_failed_with_exception(f"No image found with ID '{image_id}'", True)
 
     def test_get_with_invalid_id(self):
         """Test getting an image with an invalid image ID."""
@@ -645,7 +645,7 @@ class TestDelete(DeleteDSL):
 
         self.mock_delete(0)
         self.call_delete_expecting_error(image_id, MissingRecordError)
-        self.check_delete_failed_with_exception(f"No image found with ID: {image_id}", assert_delete=True)
+        self.check_delete_failed_with_exception(f"No image found with ID '{image_id}'", assert_delete=True)
 
     def test_delete_invalid_id(self):
         """Test deleting an image with an invalid ID."""


### PR DESCRIPTION
To make ID mentions consistent with IMS api

## Description

Update ID mentions in error and logging messages to be formatted as `ID '%s'` to be consistent with IMS api

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

connect to #225 
