### PR TITLE
Resolve boto3/botocore upgrade e2e test failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: example
 
   minio:
-    image: minio/minio:RELEASE.2024-09-13T20-26-02Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: object-storage-minio
     command: minio server /data
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - minio
     entrypoint: >
       /bin/sh -c "
+      sleep 10;
       /usr/bin/mc alias set object-storage http://localhost:9000 root example_password;
       /usr/bin/mc mb object-storage/object-storage;
       /usr/bin/mc mb object-storage/test-object-storage;


### PR DESCRIPTION
## Description
Bumps the `minio` version in the `docker-compose.yml` from `RELEASE.2024-09-13T20-26-02Z` to `RELEASE.2025-09-07T16-13-09Z` to get the e2e test(s) to pass following the boto3/botocore upgrade in https://github.com/ral-facilities/object-storage-api/pull/307.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes #143 